### PR TITLE
Add CRC and xxHash support for non-cryptographic hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ sha3 = "0.10.8"
 blake2 = "0.10.6"
 blake3 = "1.8.2"
 md-5 = "0.10.6"
+twox-hash = "2.1.2"
+crc = "3.3.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ base-d is a flexible encoding framework that goes far beyond traditional base64.
 - **3 encoding modes** - Mathematical, chunked (RFC-compliant), and byte-range
 - **Auto-detection** - Automatically identify which dictionary was used to encode data
 - **Compression support** - Built-in gzip, zstd, brotli, lz4, snappy, and lzma compression with configurable levels
-- **Hashing support** - 16 cryptographic hash algorithms including SHA-256, SHA-512, BLAKE3, and more (pure Rust, no OpenSSL)
+- **Hashing support** - 22 hash algorithms: cryptographic (SHA-256, BLAKE3, etc.), CRC checksums, and xxHash (pure Rust, no OpenSSL)
 - **Custom dictionaries** - Define your own via TOML configuration
 - **Streaming support** - Memory-efficient processing for large files
 - **Library + CLI** - Use programmatically or from the command line
@@ -114,9 +114,11 @@ base-d -d base64 encoded.txt > output.txt
 # Compress large files efficiently
 base-d --compress brotli --level 11 -e base64 large_file.bin > compressed.txt
 
-# Hash files (supported: md5, sha256, sha512, blake3, and more)
+# Hash files (supported: md5, sha256, sha512, blake3, crc32, xxhash64, and more)
 echo "hello world" | base-d --hash sha256
 echo "hello world" | base-d --hash blake3 -e base64
+echo "hello world" | base-d --hash crc32
+echo "hello world" | base-d --hash xxhash64
 base-d --hash sha256 document.pdf
 ```
 


### PR DESCRIPTION
This PR adds CRC checksums and xxHash algorithms for ultra-fast non-cryptographic hashing use cases.

## New Algorithms Added

### CRC Checksums (4 algorithms)
- **CRC-16** - Simple error detection
- **CRC-32** - ZIP, Ethernet, PNG files (ISO-HDLC)
- **CRC-32C** - iSCSI, Btrfs (Castagnoli variant)
- **CRC-64** - Large data integrity (ECMA-182)

### xxHash (2 algorithms)
- **xxHash32** - 32-bit ultra-fast hash (~12 GB/s)
- **xxHash64** - 64-bit ultra-fast hash (~15 GB/s)

## Features
- ✅ Pure Rust implementations
- ✅ No C dependencies
- ✅ 10x+ faster than cryptographic hashes
- ✅ Perfect for non-security use cases
- ✅ CLI integration via `--hash` flag
- ✅ 6 new tests (71 total passing)

## Use Cases
- **CRC**: File integrity, error detection, ZIP/PNG compatibility
- **xxHash**: Hash tables, cache keys, data deduplication, fast checksums

## Dependencies
- `crc` v3.3.0 - CRC implementations
- `twox-hash` v2.1.2 - xxHash implementations

## Examples
```bash
# CRC32 checksum (ZIP compatible)
echo "hello world" | base-d --hash crc32
# Output: af083b2d

# xxHash64 (ultra-fast)
echo "hello world" | base-d --hash xxhash64
# Output: 5215e13b207d6d8c

# CRC32C encoded as base64
echo "hello world" | base-d --hash crc32c -e base64
# Output: 8P9ykg==
```

## Documentation
- Updated HASHING.md with algorithm comparison and performance benchmarks
- Added use case guide: when to use cryptographic vs non-cryptographic
- Updated README.md with CRC and xxHash examples

## Testing
All 71 tests pass (65 existing + 6 new CRC/xxHash tests)

**Total hash algorithms: 22** (16 cryptographic + 4 CRC + 2 xxHash)