### PR TITLE
Add xxHash3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ base-d is a flexible encoding framework that goes far beyond traditional base64.
 - **3 encoding modes** - Mathematical, chunked (RFC-compliant), and byte-range
 - **Auto-detection** - Automatically identify which dictionary was used to encode data
 - **Compression support** - Built-in gzip, zstd, brotli, lz4, snappy, and lzma compression with configurable levels
-- **Hashing support** - 22 hash algorithms: cryptographic (SHA-256, BLAKE3, etc.), CRC checksums, and xxHash (pure Rust, no OpenSSL)
+- **Hashing support** - 24 hash algorithms: cryptographic (SHA-256, BLAKE3, etc.), CRC checksums, and xxHash including xxHash3 (pure Rust, no OpenSSL)
 - **Custom dictionaries** - Define your own via TOML configuration
 - **Streaming support** - Memory-efficient processing for large files
 - **Library + CLI** - Use programmatically or from the command line
@@ -114,11 +114,11 @@ base-d -d base64 encoded.txt > output.txt
 # Compress large files efficiently
 base-d --compress brotli --level 11 -e base64 large_file.bin > compressed.txt
 
-# Hash files (supported: md5, sha256, sha512, blake3, crc32, xxhash64, and more)
+# Hash files (supported: md5, sha256, sha512, blake3, crc32, xxhash64, xxhash3, and more)
 echo "hello world" | base-d --hash sha256
 echo "hello world" | base-d --hash blake3 -e base64
 echo "hello world" | base-d --hash crc32
-echo "hello world" | base-d --hash xxhash64
+echo "hello world" | base-d --hash xxhash3
 base-d --hash sha256 document.pdf
 ```
 

--- a/docs/HASHING.md
+++ b/docs/HASHING.md
@@ -40,6 +40,8 @@ base-d includes built-in support for multiple hash algorithms including cryptogr
 |-----------|------|-------------|----------|
 | **xxHash32** | `--hash xxhash32` | 32 bits (4 bytes) | Hash tables, cache keys |
 | **xxHash64** | `--hash xxhash64` | 64 bits (8 bytes) | Fast checksums, deduplication |
+| **xxHash3-64** | `--hash xxhash3` | 64 bits (8 bytes) | Newest, fastest 64-bit hash |
+| **xxHash3-128** | `--hash xxhash3-128` | 128 bits (16 bytes) | Newest, 128-bit output |
 
 ## Basic Usage
 
@@ -65,6 +67,10 @@ echo "hello world" | base-d --hash crc32
 # xxHash64 (ultra-fast non-cryptographic)
 echo "hello world" | base-d --hash xxhash64
 # Output: 5215e13b207d6d8c
+
+# xxHash3 (newest, fastest)
+echo "hello world" | base-d --hash xxhash3
+# Output: d42f7ed4b73c6bde
 ```
 
 ### Hash with Custom Encoding
@@ -84,6 +90,10 @@ echo "hello world" | base-d --hash sha512 -e emoji_faces
 # CRC32C encoded as base64
 echo "hello world" | base-d --hash crc32c -e base64
 # Output: 8P9ykg==
+
+# xxHash3-128 encoded as base64
+echo "hello world" | base-d --hash xxhash3-128 -e base64
+# Output: 7vrJ2HEAzRM2suczpUhEJQ==
 ```
 
 ### Hash Files
@@ -132,10 +142,11 @@ echo "data" | base-d --hash sha512 | base-d --compress gzip -e base64
 
 **Non-Cryptographic** (Much faster):
 
-1. **xxHash64**: ~15 GB/s (ultra-fast)
-2. **xxHash32**: ~12 GB/s
-3. **CRC32C** (hardware): ~10 GB/s
-4. **CRC32**: ~1 GB/s
+1. **xxHash3-64**: ~30 GB/s (newest, fastest)
+2. **xxHash64**: ~15 GB/s (ultra-fast)
+3. **xxHash32**: ~12 GB/s
+4. **CRC32C** (hardware): ~10 GB/s
+5. **CRC32**: ~1 GB/s
 
 ### Use Case Guide
 
@@ -150,9 +161,9 @@ echo "data" | base-d --hash sha512 | base-d --compress gzip -e base64
 | **Non-Cryptographic** | |
 | File integrity (fast) | CRC32, CRC32C |
 | ZIP/PNG compatibility | CRC32 |
-| Hash tables | xxHash32, xxHash64 |
-| Data deduplication | xxHash64, CRC64 |
-| Cache keys | xxHash32, xxHash64 |
+| Hash tables | xxHash3, xxHash32, xxHash64 |
+| Data deduplication | xxHash3, xxHash64, CRC64 |
+| Cache keys | xxHash3, xxHash32, xxHash64 |
 | Legacy compatibility | MD5, CRC16 |
 
 ### When to Use What
@@ -182,7 +193,7 @@ All hash algorithms are implemented in **pure Rust** with:
 
 **Non-Cryptographic**:
 - `crc` - CRC16, CRC32, CRC32C, CRC64
-- `twox-hash` - xxHash32, xxHash64
+- `twox-hash` - xxHash32, xxHash64, xxHash3-64, xxHash3-128
 
 ## Library API
 


### PR DESCRIPTION
This PR adds xxHash3-64 and xxHash3-128 algorithms, the newest and fastest variants of xxHash.

## New Algorithms

- **xxHash3-64** (`--hash xxhash3`) - 64-bit output, ~30 GB/s (2x faster than xxHash64)
- **xxHash3-128** (`--hash xxhash3-128`) - 128-bit output, ~30 GB/s

## Features
- ✅ Pure Rust implementation via `twox-hash` crate
- ✅ Fastest non-cryptographic hash available
- ✅ Perfect for high-performance use cases
- ✅ CLI integration with alias support
- ✅ 2 new tests (73 total passing)

## Implementation
Used the correct module paths:
- `twox_hash::xxhash3_64::Hasher`
- `twox_hash::xxhash3_128::Hasher`

## Examples
```bash
# xxHash3-64 (fastest)
echo "hello world" | base-d --hash xxhash3
# Output: d42f7ed4b73c6bde

# xxHash3-128 encoded as base64
echo "hello world" | base-d --hash xxhash3-128 -e base64
# Output: 7vrJ2HEAzRM2suczpUhEJQ==
```

## Documentation
- Updated HASHING.md with xxHash3 performance data (~30 GB/s)
- Added xxHash3 to use case guide
- Updated README.md with examples

## Testing
All 73 tests pass (71 existing + 2 new xxHash3 tests)

**Total hash algorithms: 24** (16 cryptographic + 4 CRC + 4 xxHash)