### PR TITLE
Add xxHash seed and secret configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,10 @@ sha3 = "0.10.8"
 blake2 = "0.10.6"
 blake3 = "1.8.2"
 md-5 = "0.10.6"
-twox-hash = "2.1.2"
+twox-hash = { version = "2.1.2", default-features = false, features = ["std", "xxhash32", "xxhash64", "xxhash3_64", "xxhash3_128"] }
 crc = "3.3.0"
 hex = "0.4.3"
+shellexpand = "3.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ echo "hello world" | base-d --hash blake3 -e base64
 echo "hello world" | base-d --hash crc32
 echo "hello world" | base-d --hash xxhash3
 base-d --hash sha256 document.pdf
+
+# Hash with custom seed
+echo "hello world" | base-d --hash xxhash64 --hash-seed 42
+
+# Hash with secret (XXH3 only)
+cat secret.bin | base-d --hash xxhash3 --hash-secret-stdin data.bin
 ```
 
 ## Installation

--- a/dictionaries-example.toml
+++ b/dictionaries-example.toml
@@ -12,3 +12,10 @@ mode = "base_conversion"
 [alphabets.my_base100]
 mode = "byte_range"
 start_codepoint = 128000  # Different range than default base100
+
+# xxHash Configuration
+[settings.xxhash]
+# Default seed for all xxHash algorithms (0-18446744073709551615)
+default_seed = 0
+# Path to secret file for XXH3 variants (must be >= 136 bytes)
+# default_secret_file = "~/.config/base-d/xxh3-secret.bin"

--- a/docs/STREAMING.md
+++ b/docs/STREAMING.md
@@ -90,6 +90,41 @@ real    0m0.47s
 
 The ~4% overhead is acceptable for the memory savings.
 
+## xxHash Configuration in Streaming
+
+When using streaming mode with hashing enabled, you can configure xxHash algorithms with custom seeds and secrets (for XXH3 variants). This is particularly useful for large files where you want consistent hash customization without loading the entire file into memory.
+
+### CLI Usage
+
+```bash
+# Stream encode with xxHash and custom seed
+base-d --stream -e base64 --hash xxhash64 --hash-seed 42 large_file.bin > encoded.txt
+
+# Stream with XXH3 secret
+cat secret.bin | base-d --stream --hash xxhash3 --hash-secret-stdin < huge_data.bin > output.txt
+
+# Combine streaming, compression, and custom hash
+base-d --stream --compress zstd --hash xxhash3-128 --hash-seed 999 multi_gb_file.bin > compressed.txt
+```
+
+### API Usage
+
+```rust
+use base_d::{StreamingEncoder, XxHashConfig, HashAlgorithm, Dictionary};
+use std::fs::File;
+
+// Create streaming encoder with custom xxHash config
+let xxhash_config = XxHashConfig::with_seed(42);
+
+let mut encoder = StreamingEncoder::new(&dictionary, output)
+    .with_xxhash_config(xxhash_config)
+    .with_hash(HashAlgorithm::XxHash64);
+
+encoder.encode(&mut large_file)?;
+```
+
+The hash is computed incrementally as data streams through, so memory usage remains constant regardless of file size or hash configuration.
+
 ## When to Use Streaming
 
 ### Use Streaming When:

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -62,12 +62,26 @@ pub struct CompressionConfig {
     pub default_level: u32,
 }
 
+/// xxHash-specific settings.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct XxHashSettings {
+    /// Default seed for xxHash algorithms
+    #[serde(default)]
+    pub default_seed: u64,
+    /// Path to default secret file for XXH3 variants
+    #[serde(default)]
+    pub default_secret_file: Option<String>,
+}
+
 /// Global settings for base-d.
 #[derive(Debug, Deserialize, Clone, Default)]
 pub struct Settings {
     /// Default dictionary to use when compressing without explicit encoding
     #[serde(default = "default_dictionary")]
     pub default_dictionary: String,
+    /// xxHash configuration
+    #[serde(default)]
+    pub xxhash: XxHashSettings,
 }
 
 fn default_dictionary() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub use encoders::streaming::{StreamingEncoder, StreamingDecoder};
 pub use encoders::encoding::DecodeError;
 pub use compression::{CompressionAlgorithm, compress, decompress};
 pub use detection::{DictionaryDetector, DictionaryMatch, detect_dictionary};
-pub use hashing::{HashAlgorithm, hash};
+pub use hashing::{HashAlgorithm, hash, hash_with_config, XxHashConfig};
 
 /// Encodes binary data using the specified dictionary.
 ///


### PR DESCRIPTION
## Summary
- Add `--hash-seed` CLI flag for custom seed values (all xxHash variants)
- Add `--hash-secret-stdin` for XXH3 secret input (>= 136 bytes)
- Add `[settings.xxhash]` TOML config support
- Expose `XxHashConfig` and `hash_with_config()` in public API
- Update streaming encoder/decoder with xxhash configuration
- Trim twox-hash dependency to remove unused features

## Test plan
- [x] Unit tests pass (85 tests)
- [x] CLI tested with various seeds
- [x] Secret stdin tested with 136+ byte files
- [x] Backward compatibility verified (default seed=0)
- [x] Documentation reviewed and verified

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)