### PR TITLE
feat: dynamic alphabet switching in Matrix mode (#22)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -149,9 +149,8 @@ pub fn matrix_mode(
 
         // Check if we need to switch (time-based)
         let should_switch = match &switch_mode {
-            SwitchMode::Cycle(SwitchInterval::Time(d)) | SwitchMode::Random(SwitchInterval::Time(d)) => {
-                last_switch.elapsed() >= *d
-            }
+            SwitchMode::Cycle(SwitchInterval::Time(d))
+            | SwitchMode::Random(SwitchInterval::Time(d)) => last_switch.elapsed() >= *d,
             _ => false,
         };
 
@@ -174,7 +173,8 @@ pub fn matrix_mode(
         // Check for line-based switching
         let switch_per_line = matches!(
             &switch_mode,
-            SwitchMode::Cycle(SwitchInterval::PerLine) | SwitchMode::Random(SwitchInterval::PerLine)
+            SwitchMode::Cycle(SwitchInterval::PerLine)
+                | SwitchMode::Random(SwitchInterval::PerLine)
         );
 
         if switch_per_line {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -112,14 +112,10 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
         // Determine switch mode
         let switch_mode = if cli.cycle {
-            let interval = commands::parse_interval(
-                cli.interval.as_deref().unwrap_or("5s")
-            )?;
+            let interval = commands::parse_interval(cli.interval.as_deref().unwrap_or("5s"))?;
             commands::SwitchMode::Cycle(interval)
         } else if cli.random {
-            let interval = commands::parse_interval(
-                cli.interval.as_deref().unwrap_or("3s")
-            )?;
+            let interval = commands::parse_interval(cli.interval.as_deref().unwrap_or("3s"))?;
             commands::SwitchMode::Random(interval)
         } else if cli.dejavu {
             // Single random pick


### PR DESCRIPTION
## Summary
Closes #22

Implements dynamic alphabet switching for Matrix mode with time-based and line-based intervals.

## Usage

**Static mode (existing):**
```bash
base-d --neo                          # Default base256_matrix
base-d --neo --dejavu                 # Random pick once
```

**New: Cycle mode**
```bash
base-d --neo --dejavu --cycle                    # Cycle every 5s (default)
base-d --neo --dejavu --cycle --interval 10s     # Cycle every 10 seconds
base-d --neo --dejavu --cycle --interval line    # New alphabet each line
```

**New: Random mode**
```bash
base-d --neo --dejavu --random                   # Random every 3s (default)
base-d --neo --dejavu --random --interval 1s     # Random every 1 second
base-d --neo --dejavu --random --interval line   # Random alphabet each line
```

## Implementation

- **CLI flags**: `--cycle`, `--random`, `--interval <INTERVAL>`
- **Interval parsing**: Supports time (`5s`, `500ms`) and line-based (`line`)
- **Default intervals**: 5s for cycle, 3s for random
- **Visual feedback**: Displays current alphabet name in green
- **Starting alphabet**: Always base256_matrix (consistent Matrix look)

## Features

✅ **Time-based switching**: Change alphabets at regular intervals  
✅ **Line-based switching**: New alphabet for each line of falling code  
✅ **Cycle mode**: Predictable rotation through all dictionaries  
✅ **Random mode**: Unpredictable switching for maximum variety  
✅ **Configurable intervals**: User control over timing  
✅ **Sensible defaults**: Works without specifying intervals  

## Test Plan
- [x] Compiles successfully
- [x] Help text displays correctly
- [x] Flag validation (errors on conflicting flags)
- [ ] Visual test: Run each mode and verify switching behavior