### PR TITLE
feat: add interactive controls to Matrix mode (#69)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.5", features = ["derive"] }
 dirs = "5.0"
 rand = "0.8"
 terminal_size = "0.3"
+crossterm = "0.28"
 flate2 = "1.0"
 brotli = "7.0"
 zstd = "0.13"


### PR DESCRIPTION
## Summary
Adds keyboard controls to Matrix mode for better interactivity:
- **ESC** to skip the intro sequence (works in all modes)
- **SPACE** to randomly switch to a different alphabet (static mode only)
- **LEFT/RIGHT arrows** to cycle through alphabets (static mode only)

## Implementation Details
- Added `crossterm` dependency for non-blocking keyboard input
- Intro sequence now polls for ESC key during the character-by-character typing animation
- Main Matrix loop includes keyboard event handling when in static mode
- Visual feedback shows current alphabet name when manually switching
- Controls are automatically disabled when using `--cycle` or `--random` flags (auto-switching modes)

## Testing
Manual testing confirms:
- ESC successfully skips intro across all modes
- SPACE provides random alphabet switching in static mode
- LEFT/RIGHT arrows cycle through sorted dictionary list
- Controls properly disabled in cycle/random modes
- Alphabet name displays correctly on switches

## Related
Closes #69

## Example Usage
```bash
# Static mode with manual controls (default)
base-d --neo

# Auto-cycling mode (keyboard controls disabled except ESC)
base-d --neo --dejavu --cycle --interval 5s
```