### PR TITLE
fix: enable keyboard controls when using --neo --dejavu (#72)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -15,7 +15,6 @@ pub enum SwitchInterval {
 
 pub enum SwitchMode {
     Static,
-    RandomOnce,
     Cycle(SwitchInterval),
     Random(SwitchInterval),
 }
@@ -123,14 +122,7 @@ pub fn matrix_mode(
     thread::sleep(Duration::from_millis(500));
 
     // Setup for switching
-    let mut current_alphabet_name = match &switch_mode {
-        SwitchMode::RandomOnce => {
-            let name = select_random_dictionary(config, false)?;
-            eprintln!("dejavu: Matrix mode using {}", name);
-            name
-        }
-        _ => initial_alphabet.to_string(),
-    };
+    let mut current_alphabet_name = initial_alphabet.to_string();
 
     // For cycling: build sorted dictionary list
     let sorted_dicts: Vec<String> = if matches!(switch_mode, SwitchMode::Cycle(_)) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -117,18 +117,23 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         } else if cli.random {
             let interval = commands::parse_interval(cli.interval.as_deref().unwrap_or("3s"))?;
             commands::SwitchMode::Random(interval)
-        } else if cli.dejavu {
-            // Single random pick
-            commands::SwitchMode::RandomOnce
         } else {
-            // Static mode
+            // Static mode (allows keyboard controls)
             commands::SwitchMode::Static
         };
 
-        let initial_alphabet = alphabet_opt
-            .as_deref()
-            .unwrap_or("base256_matrix")
-            .to_string();
+        // Determine initial alphabet
+        // If --dejavu is set and no explicit alphabet, pick random
+        let initial_alphabet = if cli.dejavu && alphabet_opt.is_none() {
+            let random_dict = commands::select_random_dictionary(&config, false)?;
+            eprintln!("dejavu: Matrix mode using {}", random_dict);
+            random_dict
+        } else {
+            alphabet_opt
+                .as_deref()
+                .unwrap_or("base256_matrix")
+                .to_string()
+        };
 
         return commands::matrix_mode(&config, &initial_alphabet, switch_mode);
     }


### PR DESCRIPTION
## Summary
Fixes keyboard controls not working when running Matrix mode with `--neo --dejavu`.

## Problem
The `--dejavu` flag was setting the mode to `RandomOnce`, which disabled keyboard controls (SPACE/LEFT/RIGHT). Users expect to be able to manually switch alphabets even when starting with a random one.

## Solution
- Removed `SwitchMode::RandomOnce` enum variant (no longer needed)
- `--dejavu` now uses `Static` mode, enabling keyboard controls
- Random alphabet selection moved to CLI argument parsing
- Only `--cycle` and `--random` disable keyboard controls

## Changes
- `src/cli/commands.rs` - Removed `RandomOnce` variant and its handling
- `src/cli/mod.rs` - Random selection at startup, uses `Static` mode

## Testing
- Verified keyboard controls work with `--neo --dejavu`
- All tests pass (229 passed)
- Build successful

## Closes
#72