### PR TITLE
fix: resolve security blockers #74 #75 #76 #77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,11 @@ shellexpand = "3.1"
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 
+[dev-dependencies.cargo-husky]
+version = "1"
+default-features = false
+features = ["prepush-hook", "run-cargo-fmt", "run-cargo-clippy"]
+
 [lib]
 name = "base_d"
 path = "src/lib.rs"


### PR DESCRIPTION
## Summary

Resolves all 4 security blockers identified during the Construct review:

- **#74** - Add SIMD bounds checking in LUT codec
- **#75** - Fix path traversal in custom alphabet/secret loading
- **#76** - Add input size limits with `--max-size` and `--force` flags
- **#77** - Fix Base32 padding validation per RFC 4648

## Changes

### SIMD Bounds Checking (#74)
Added bounds validation before all unsafe SIMD memory access in 12 functions across `src/simd/lut/large.rs`.

### Path Traversal Fix (#75)
Added `validate_config_path()` in `src/cli/config.rs` that canonicalizes paths and validates they're within `~/.config/base-d/`.

### Input Size Limits (#76)
- Added `--max-size` flag (default 100MB)
- Added `--force` flag to override for files (with warning)
- Stdin remains hard-limited (can't pre-check size)
- Pre-checks file size before reading to avoid memory exhaustion

### Base32 Padding Validation (#77)
Added RFC 4648 compliant padding validation in both x86_64 and aarch64 SIMD paths.

## Test plan

- [x] `cargo test` - 231 tests pass
- [x] `cargo clippy -- -D warnings` - clean
- [ ] Manual testing of --max-size and --force flags
- [ ] Verify path traversal is blocked

Closes #74, closes #75, closes #76, closes #77