### PR TITLE
feat: add builder pattern for Dictionary construction

### DIFF
--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -8,13 +8,12 @@ fn get_dictionary(name: &str) -> Dictionary {
     match dictionary_config.mode {
         EncodingMode::ByteRange => {
             let start = dictionary_config.start_codepoint.unwrap();
-            Dictionary::new_with_mode_and_range(
-                Vec::new(),
-                dictionary_config.mode.clone(),
-                None,
-                Some(start),
-            )
-            .unwrap()
+            Dictionary::builder()
+                .chars(Vec::new())
+                .mode(dictionary_config.mode.clone())
+                .start_codepoint(start)
+                .build()
+                .unwrap()
         }
         _ => {
             let chars: Vec<char> = dictionary_config.chars.chars().collect();
@@ -22,7 +21,13 @@ fn get_dictionary(name: &str) -> Dictionary {
                 .padding
                 .as_ref()
                 .and_then(|s| s.chars().next());
-            Dictionary::new_with_mode(chars, dictionary_config.mode.clone(), padding).unwrap()
+            let mut builder = Dictionary::builder()
+                .chars(chars)
+                .mode(dictionary_config.mode.clone());
+            if let Some(pad) = padding {
+                builder = builder.padding(pad);
+            }
+            builder.build().unwrap()
         }
     }
 }

--- a/examples/auto_simd.rs
+++ b/examples/auto_simd.rs
@@ -12,21 +12,27 @@ fn main() {
 
     // 1. Standard base64 - uses specialized SIMD
     let base64_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let dict = Dictionary::new(base64_chars.chars().collect()).unwrap();
+    let dict = Dictionary::builder()
+        .chars(base64_chars.chars().collect())
+        .build()
+        .unwrap();
     let encoded = encode(data, &dict);
     println!("Standard base64 (specialized SIMD):");
     println!("  {}\n", encoded);
 
     // 2. Standard hex - uses specialized SIMD
     let hex_chars = "0123456789abcdef";
-    let dict = Dictionary::new(hex_chars.chars().collect()).unwrap();
+    let dict = Dictionary::builder()
+        .chars(hex_chars.chars().collect())
+        .build()
+        .unwrap();
     let encoded = encode(data, &dict);
     println!("Standard hex (specialized SIMD):");
     println!("  {}\n", encoded);
 
     // 3. Custom sequential base16 - uses GenericSimdCodec
     let custom_hex: Vec<char> = (0x21..0x31).map(|cp| char::from_u32(cp).unwrap()).collect();
-    let dict = Dictionary::new(custom_hex).unwrap();
+    let dict = Dictionary::builder().chars(custom_hex).build().unwrap();
     let encoded = encode(data, &dict);
     println!("Custom base16 starting at '!' (GenericSimdCodec):");
     println!("  {}\n", encoded);
@@ -35,14 +41,17 @@ fn main() {
     let custom_b64: Vec<char> = (0x100..0x140)
         .map(|cp| char::from_u32(cp).unwrap())
         .collect();
-    let dict = Dictionary::new(custom_b64).unwrap();
+    let dict = Dictionary::builder().chars(custom_b64).build().unwrap();
     let encoded = encode(data, &dict);
     println!("Custom base64 at U+0100 (GenericSimdCodec):");
     println!("  {}\n", encoded);
 
     // 5. Arbitrary dictionary - falls back to scalar
     let arbitrary = "ZYXWVUTSRQPONMLKJIHGFEDCBAzyxwvutsrqponmlkjihgfedcba9876543210+/";
-    let dict = Dictionary::new(arbitrary.chars().collect()).unwrap();
+    let dict = Dictionary::builder()
+        .chars(arbitrary.chars().collect())
+        .build()
+        .unwrap();
     let encoded = encode(data, &dict);
     println!("Arbitrary shuffled base64 (scalar fallback):");
     println!("  {}\n", encoded);

--- a/examples/base1024_demo.rs
+++ b/examples/base1024_demo.rs
@@ -6,7 +6,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let base1024_config = config.get_dictionary("base1024").unwrap();
 
     let chars: Vec<char> = base1024_config.chars.chars().collect();
-    let dictionary = Dictionary::new_with_mode(chars, base1024_config.mode.clone(), None)?;
+    let dictionary = Dictionary::builder()
+        .chars(chars)
+        .mode(base1024_config.mode.clone())
+        .build()?;
 
     println!("Base1024 Dictionary Demo");
     println!("======================");
@@ -33,8 +36,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .padding
         .as_ref()
         .and_then(|s| s.chars().next());
-    let base64_dictionary =
-        Dictionary::new_with_mode(base64_chars, base64_config.mode.clone(), base64_padding)?;
+    let mut builder = Dictionary::builder()
+        .chars(base64_chars)
+        .mode(base64_config.mode.clone());
+    if let Some(pad) = base64_padding {
+        builder = builder.padding(pad);
+    }
+    let base64_dictionary = builder.build()?;
 
     let base64_encoded = encode(data, &base64_dictionary);
 

--- a/examples/custom_dictionary.rs
+++ b/examples/custom_dictionary.rs
@@ -2,7 +2,10 @@ use base_d::{decode, encode, Dictionary};
 
 fn main() {
     // Create a custom dictionary with just 4 DNA bases
-    let dna_dictionary = Dictionary::from_str("ACGT").unwrap();
+    let dna_dictionary = Dictionary::builder()
+        .chars_from_str("ACGT")
+        .build()
+        .unwrap();
 
     println!("DNA Dictionary (base-4)");
     println!("=====================\n");

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -10,8 +10,13 @@ fn main() {
         .padding
         .as_ref()
         .and_then(|s| s.chars().next());
-    let dictionary =
-        Dictionary::new_with_mode(chars, dictionary_config.mode.clone(), padding).unwrap();
+    let mut builder = Dictionary::builder()
+        .chars(chars)
+        .mode(dictionary_config.mode.clone());
+    if let Some(pad) = padding {
+        builder = builder.padding(pad);
+    }
+    let dictionary = builder.build().unwrap();
 
     let data = b"Hello, World!";
 

--- a/examples/matrix_demo.rs
+++ b/examples/matrix_demo.rs
@@ -9,7 +9,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matrix_config = config.get_dictionary("base256_matrix").unwrap();
 
     let chars: Vec<char> = matrix_config.chars.chars().collect();
-    let dictionary = Dictionary::new_with_mode(chars, matrix_config.mode.clone(), None)?;
+    let dictionary = Dictionary::builder()
+        .chars(chars)
+        .mode(matrix_config.mode.clone())
+        .build()?;
 
     println!("Dictionary: base256_matrix");
     println!("Size: {} characters", dictionary.base());
@@ -47,19 +50,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let test_data = b"Matrix";
 
     // Test with chunked mode
-    let chunked_dictionary = Dictionary::new_with_mode(
-        matrix_config.chars.chars().collect(),
-        base_d::EncodingMode::Chunked,
-        None,
-    )?;
+    let chunked_dictionary = Dictionary::builder()
+        .chars(matrix_config.chars.chars().collect())
+        .mode(base_d::EncodingMode::Chunked)
+        .build()?;
     let chunked_encoded = encode(test_data, &chunked_dictionary);
 
     // Test with mathematical mode
-    let math_dictionary = Dictionary::new_with_mode(
-        matrix_config.chars.chars().collect(),
-        base_d::EncodingMode::BaseConversion,
-        None,
-    )?;
+    let math_dictionary = Dictionary::builder()
+        .chars(matrix_config.chars.chars().collect())
+        .mode(base_d::EncodingMode::BaseConversion)
+        .build()?;
     let math_encoded = encode(test_data, &math_dictionary);
 
     println!("Input:       '{}'", String::from_utf8_lossy(test_data));
@@ -89,8 +90,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .padding
         .as_ref()
         .and_then(|s| s.chars().next());
-    let base64_dictionary =
-        Dictionary::new_with_mode(base64_chars, base64_config.mode.clone(), base64_padding)?;
+    let mut builder = Dictionary::builder()
+        .chars(base64_chars)
+        .mode(base64_config.mode.clone());
+    if let Some(pad) = base64_padding {
+        builder = builder.padding(pad);
+    }
+    let base64_dictionary = builder.build()?;
 
     let matrix_encoded = encode(long_message, &dictionary);
     let base64_encoded = encode(long_message, &base64_dictionary);

--- a/examples/simd_check.rs
+++ b/examples/simd_check.rs
@@ -40,7 +40,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .padding
         .as_ref()
         .and_then(|s| s.chars().next());
-    let dictionary = Dictionary::new_with_mode(chars, base64_config.mode.clone(), padding)?;
+    let mut builder = Dictionary::builder()
+        .chars(chars)
+        .mode(base64_config.mode.clone());
+    if let Some(pad) = padding {
+        builder = builder.padding(pad);
+    }
+    let dictionary = builder.build()?;
 
     let test_data = b"Hello, SIMD World! This is a performance test.";
     let encoded = encode(test_data, &dictionary);

--- a/examples/test_base256_simd.rs
+++ b/examples/test_base256_simd.rs
@@ -5,7 +5,11 @@ fn main() {
     let config = DictionaryRegistry::load_default().unwrap();
     let dict_config = config.get_dictionary("base256_matrix").unwrap();
     let chars: Vec<char> = dict_config.chars.chars().collect();
-    let dict = Dictionary::new_with_mode(chars, dict_config.mode.clone(), None).unwrap();
+    let dict = Dictionary::builder()
+        .chars(chars)
+        .mode(dict_config.mode.clone())
+        .build()
+        .unwrap();
 
     println!("Testing base256 SIMD implementation...\n");
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -221,7 +221,10 @@ pub fn matrix_mode(
             .ok_or(format!("{} dictionary not found", current_dictionary_name))?;
 
         let chars: Vec<char> = dictionary_config.chars.chars().collect();
-        let dictionary = Dictionary::new_with_mode(chars, dictionary_config.mode.clone(), None)?;
+        let dictionary = Dictionary::builder()
+            .chars(chars)
+            .mode(dictionary_config.mode.clone())
+            .build()?;
 
         // Check if we need to switch (time-based)
         let should_switch = match &switch_mode {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -44,13 +44,12 @@ pub fn create_dictionary(
             let start = dictionary_config
                 .start_codepoint
                 .ok_or("ByteRange mode requires start_codepoint")?;
-            Dictionary::new_with_mode_and_range(
-                Vec::new(),
-                dictionary_config.mode.clone(),
-                None,
-                Some(start),
-            )
-            .map_err(|e| format!("Invalid dictionary: {}", e))?
+            Dictionary::builder()
+                .chars(Vec::new())
+                .mode(dictionary_config.mode.clone())
+                .start_codepoint(start)
+                .build()
+                .map_err(|e| format!("Invalid dictionary: {}", e))?
         }
         _ => {
             let chars: Vec<char> = dictionary_config.chars.chars().collect();
@@ -58,7 +57,14 @@ pub fn create_dictionary(
                 .padding
                 .as_ref()
                 .and_then(|s| s.chars().next());
-            Dictionary::new_with_mode(chars, dictionary_config.mode.clone(), padding)
+            let mut builder = Dictionary::builder()
+                .chars(chars)
+                .mode(dictionary_config.mode.clone());
+            if let Some(pad) = padding {
+                builder = builder.padding(pad);
+            }
+            builder
+                .build()
                 .map_err(|e| format!("Invalid dictionary: {}", e))?
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(deprecated)]
 #![allow(clippy::should_implement_trait)]
 #![allow(clippy::derivable_impls)]
 #![allow(clippy::manual_div_ceil)]
@@ -161,7 +162,7 @@ mod simd;
 pub use core::config::{
     CompressionConfig, DictionaryConfig, DictionaryRegistry, EncodingMode, Settings,
 };
-pub use core::dictionary::Dictionary;
+pub use core::dictionary::{Dictionary, DictionaryBuilder};
 pub use encoders::algorithms::{find_closest_dictionary, DecodeError, DictionaryNotFoundError};
 pub use encoders::streaming::{StreamingDecoder, StreamingEncoder};
 pub use features::{


### PR DESCRIPTION
## Summary
- Add `DictionaryBuilder` with fluent API for constructing dictionaries
- Methods: `chars()`, `chars_from_str()`, `mode()`, `padding()`, `start_codepoint()`, `build()`
- Deprecate old constructors (`new`, `new_with_mode`, `new_with_mode_and_range`, `from_str`)
- Migrate all examples, benchmarks, and CLI to use builder pattern
- Export `DictionaryBuilder` from crate root

## New API

```rust
// Before
let dict = Dictionary::new_with_mode(chars, EncodingMode::Chunked, Some('='))?;

// After
let dict = Dictionary::builder()
    .chars(chars)
    .mode(EncodingMode::Chunked)
    .padding('=')
    .build()?;
```

## Benefits
- Extensible without constructor explosion
- Self-documenting
- Scales to more parameters gracefully

Closes #57