### PR TITLE
Add comprehensive SIMD benchmarking infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ base-d is a flexible encoding framework that goes far beyond traditional base64.
 
 ### Performance
 
-- **SIMD-Accelerated** - Runtime SSSE3 detection for ~4x faster base64 encoding on x86_64
-- **Highly Optimized** - Fast lookup tables, memory pre-allocation, CPU cache-friendly chunking
-- **~370 MiB/s** base64 encoding (scalar), **~1.5 GiB/s** with SIMD
+- **SIMD-Accelerated** - Runtime AVX2/SSSE3 (x86_64) and NEON (ARM) detection
+- **Specialized SIMD** - Hardcoded lookup tables for RFC dictionaries (base64, base32, base16)
+- **LUT SIMD** - Runtime lookup tables for arbitrary dictionaries
+- **~500 MiB/s** base64 encode, **~7.4 GiB/s** base64 decode with specialized SIMD
 - **Streaming Mode** - Process multi-GB files with constant 4KB memory usage
 
 ### Extensive Dictionary Collection
@@ -343,6 +344,7 @@ MIT OR Apache-2.0
 
 ### Performance
 - [SIMD Optimizations](docs/SIMD.md) - AVX2/SSSE3/NEON acceleration
+- [Benchmarking](docs/BENCHMARKING.md) - Running and interpreting benchmarks
 - [Performance Guide](docs/PERFORMANCE.md) - Benchmarks and optimization tips
 
 ### Matrix Mode

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -1,28 +1,32 @@
-use base_d::{Dictionary, DictionaryRegistry, EncodingMode, decode, encode};
+use base_d::{
+    Dictionary, DictionaryRegistry, EncodingMode,
+    bench::{
+        EncodingPath, PlatformInfo, decode_with_path, detect_available_paths, encode_with_path,
+    },
+};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
 
-fn get_dictionary(name: &str) -> Dictionary {
-    let config = DictionaryRegistry::load_default().unwrap();
-    let dictionary_config = config.get_dictionary(name).unwrap();
+/// Test data sizes for benchmarking
+const SIZES: &[usize] = &[64, 256, 1024, 4096, 16384, 65536];
+
+fn get_dictionary(name: &str) -> Option<Dictionary> {
+    let config = DictionaryRegistry::load_default().ok()?;
+    let dictionary_config = config.get_dictionary(name)?;
     let effective_mode = dictionary_config.effective_mode();
 
     match effective_mode {
         EncodingMode::ByteRange => {
-            let start = dictionary_config.start_codepoint.unwrap();
+            let start = dictionary_config.start_codepoint?;
             Dictionary::builder()
                 .chars(Vec::new())
                 .mode(effective_mode)
                 .start_codepoint(start)
                 .build()
-                .unwrap()
+                .ok()
         }
         _ => {
-            let chars: Vec<char> = dictionary_config
-                .effective_chars()
-                .unwrap()
-                .chars()
-                .collect();
+            let chars: Vec<char> = dictionary_config.effective_chars().ok()?.chars().collect();
             let padding = dictionary_config
                 .padding
                 .as_ref()
@@ -31,143 +35,204 @@ fn get_dictionary(name: &str) -> Dictionary {
             if let Some(pad) = padding {
                 builder = builder.padding(pad);
             }
-            builder.build().unwrap()
+            builder.build().ok()
         }
     }
 }
 
-fn bench_encode_base64(c: &mut Criterion) {
-    let dictionary = get_dictionary("base64");
-    let mut group = c.benchmark_group("encode_base64");
-
-    for size in [64, 256, 1024, 4096, 16384].iter() {
-        group.throughput(Throughput::Bytes(*size as u64));
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-
-        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
-            b.iter(|| encode(black_box(data), black_box(&dictionary)));
-        });
+fn generate_random_data(size: usize) -> Vec<u8> {
+    // Use a simple PRNG for reproducible "random" data
+    let mut data = Vec::with_capacity(size);
+    let mut state: u64 = 0xDEADBEEF;
+    for _ in 0..size {
+        // Simple xorshift
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        data.push(state as u8);
     }
+    data
+}
+
+/// Benchmark encoding for a single dictionary across all available paths
+fn bench_encode_dictionary(c: &mut Criterion, dict_name: &str) {
+    let Some(dictionary) = get_dictionary(dict_name) else {
+        eprintln!("Skipping {}: dictionary not found", dict_name);
+        return;
+    };
+
+    let paths = detect_available_paths(&dictionary);
+    let mut group = c.benchmark_group(format!("encode/{}", dict_name));
+
+    for &size in SIZES {
+        let data = generate_random_data(size);
+        group.throughput(Throughput::Bytes(size as u64));
+
+        for &path in &paths {
+            let id = BenchmarkId::new(path.to_string(), size);
+            group.bench_with_input(id, &data, |b, data| {
+                b.iter(|| encode_with_path(black_box(data), black_box(&dictionary), path));
+            });
+        }
+    }
+
     group.finish();
 }
 
-fn bench_decode_base64(c: &mut Criterion) {
-    let dictionary = get_dictionary("base64");
-    let mut group = c.benchmark_group("decode_base64");
+/// Benchmark decoding for a single dictionary across all available paths
+fn bench_decode_dictionary(c: &mut Criterion, dict_name: &str) {
+    let Some(dictionary) = get_dictionary(dict_name) else {
+        eprintln!("Skipping {}: dictionary not found", dict_name);
+        return;
+    };
 
-    for size in [64, 256, 1024, 4096, 16384].iter() {
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-        let encoded = encode(&data, &dictionary);
+    let paths = detect_available_paths(&dictionary);
+    let mut group = c.benchmark_group(format!("decode/{}", dict_name));
 
-        group.throughput(Throughput::Bytes(*size as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(size), &encoded, |b, encoded| {
-            b.iter(|| decode(black_box(encoded), black_box(&dictionary)).unwrap());
-        });
+    for &size in SIZES {
+        let data = generate_random_data(size);
+        // Pre-encode using scalar (guaranteed to work)
+        let Some(encoded) = encode_with_path(&data, &dictionary, EncodingPath::Scalar) else {
+            eprintln!("Skipping decode/{} size {}: encode failed", dict_name, size);
+            continue;
+        };
+
+        group.throughput(Throughput::Bytes(size as u64));
+
+        for &path in &paths {
+            let id = BenchmarkId::new(path.to_string(), size);
+            group.bench_with_input(id, &encoded, |b, encoded| {
+                b.iter(|| decode_with_path(black_box(encoded), black_box(&dictionary), path));
+            });
+        }
     }
+
     group.finish();
 }
 
-fn bench_encode_base32(c: &mut Criterion) {
-    let dictionary = get_dictionary("base32");
-    let mut group = c.benchmark_group("encode_base32");
-
-    for size in [64, 256, 1024, 4096, 16384].iter() {
-        group.throughput(Throughput::Bytes(*size as u64));
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-
-        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
-            b.iter(|| encode(black_box(data), black_box(&dictionary)));
-        });
-    }
-    group.finish();
+// Individual benchmark functions for criterion_group
+fn bench_base64(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base64");
+    bench_decode_dictionary(c, "base64");
 }
 
-fn bench_encode_base100(c: &mut Criterion) {
-    let dictionary = get_dictionary("base100");
-    let mut group = c.benchmark_group("encode_base100");
-
-    for size in [64, 256, 1024, 4096, 16384].iter() {
-        group.throughput(Throughput::Bytes(*size as u64));
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-
-        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
-            b.iter(|| encode(black_box(data), black_box(&dictionary)));
-        });
-    }
-    group.finish();
+fn bench_base64url(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base64url");
+    bench_decode_dictionary(c, "base64url");
 }
 
-fn bench_decode_base100(c: &mut Criterion) {
-    let dictionary = get_dictionary("base100");
-    let mut group = c.benchmark_group("decode_base100");
-
-    for size in [64, 256, 1024, 4096, 16384].iter() {
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-        let encoded = encode(&data, &dictionary);
-
-        group.throughput(Throughput::Bytes(*size as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(size), &encoded, |b, encoded| {
-            b.iter(|| decode(black_box(encoded), black_box(&dictionary)).unwrap());
-        });
-    }
-    group.finish();
+fn bench_base32(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base32");
+    bench_decode_dictionary(c, "base32");
 }
 
-fn bench_encode_hex(c: &mut Criterion) {
-    let dictionary = get_dictionary("hex");
-    let mut group = c.benchmark_group("encode_hex");
-
-    for size in [64, 256, 1024, 4096, 16384].iter() {
-        group.throughput(Throughput::Bytes(*size as u64));
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-
-        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
-            b.iter(|| encode(black_box(data), black_box(&dictionary)));
-        });
-    }
-    group.finish();
+fn bench_base32hex(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base32hex");
+    bench_decode_dictionary(c, "base32hex");
 }
 
-fn bench_encode_base1024(c: &mut Criterion) {
-    let dictionary = get_dictionary("base1024");
-    let mut group = c.benchmark_group("encode_base1024");
-
-    for size in [64, 256, 1024, 4096].iter() {
-        group.throughput(Throughput::Bytes(*size as u64));
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-
-        group.bench_with_input(BenchmarkId::from_parameter(size), &data, |b, data| {
-            b.iter(|| encode(black_box(data), black_box(&dictionary)));
-        });
-    }
-    group.finish();
+fn bench_base16(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base16");
+    bench_decode_dictionary(c, "base16");
 }
 
-fn bench_decode_base1024(c: &mut Criterion) {
-    let dictionary = get_dictionary("base1024");
-    let mut group = c.benchmark_group("decode_base1024");
+fn bench_hex(c: &mut Criterion) {
+    bench_encode_dictionary(c, "hex");
+    bench_decode_dictionary(c, "hex");
+}
 
-    for size in [64, 256, 1024, 4096].iter() {
-        let data: Vec<u8> = (0..*size).map(|i| (i % 256) as u8).collect();
-        let encoded = encode(&data, &dictionary);
+fn bench_bioctal(c: &mut Criterion) {
+    bench_encode_dictionary(c, "bioctal");
+    bench_decode_dictionary(c, "bioctal");
+}
 
-        group.throughput(Throughput::Bytes(*size as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(size), &encoded, |b, encoded| {
-            b.iter(|| decode(black_box(encoded), black_box(&dictionary)).unwrap());
-        });
-    }
-    group.finish();
+fn bench_base32_geohash(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base32_geohash");
+    bench_decode_dictionary(c, "base32_geohash");
+}
+
+fn bench_base32_zbase(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base32_zbase");
+    bench_decode_dictionary(c, "base32_zbase");
+}
+
+fn bench_base256_matrix(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base256_matrix");
+    bench_decode_dictionary(c, "base256_matrix");
+}
+
+fn bench_base58(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base58");
+    bench_decode_dictionary(c, "base58");
+}
+
+fn bench_base85(c: &mut Criterion) {
+    bench_encode_dictionary(c, "base85");
+    bench_decode_dictionary(c, "base85");
+}
+
+fn bench_cards(c: &mut Criterion) {
+    bench_encode_dictionary(c, "cards");
+    bench_decode_dictionary(c, "cards");
+}
+
+fn bench_emoji_faces(c: &mut Criterion) {
+    bench_encode_dictionary(c, "emoji_faces");
+    bench_decode_dictionary(c, "emoji_faces");
+}
+
+/// Print platform info at the start
+fn print_platform_info(_c: &mut Criterion) {
+    let info = PlatformInfo::detect();
+    eprintln!("\n╔══════════════════════════════════════════════════════════╗");
+    eprintln!("║ base-d benchmark suite                                   ║");
+    eprintln!("║ Platform: {:48} ║", info.display());
+    eprintln!("╚══════════════════════════════════════════════════════════╝\n");
 }
 
 criterion_group!(
-    benches,
-    bench_encode_base64,
-    bench_decode_base64,
-    bench_encode_base32,
-    bench_encode_base100,
-    bench_decode_base100,
-    bench_encode_hex,
-    bench_encode_base1024,
-    bench_decode_base1024,
+    name = platform_info;
+    config = Criterion::default().sample_size(10);
+    targets = print_platform_info
 );
-criterion_main!(benches);
+
+criterion_group!(
+    name = rfc_encodings;
+    config = Criterion::default();
+    targets =
+        bench_base64,
+        bench_base64url,
+        bench_base32,
+        bench_base32hex,
+        bench_base16,
+        bench_hex,
+        bench_bioctal,
+        bench_base32_geohash,
+        bench_base32_zbase
+);
+
+criterion_group!(
+    name = high_density;
+    config = Criterion::default();
+    targets = bench_base256_matrix
+);
+
+criterion_group!(
+    name = non_power_of_two;
+    config = Criterion::default().sample_size(50);
+    targets = bench_base58, bench_base85
+);
+
+criterion_group!(
+    name = fun_encodings;
+    config = Criterion::default().sample_size(50);
+    targets = bench_cards, bench_emoji_faces
+);
+
+criterion_main!(
+    platform_info,
+    rfc_encodings,
+    high_density,
+    non_power_of_two,
+    fun_encodings
+);

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,0 +1,152 @@
+# Benchmarking Suite
+
+## Output Format
+
+### Full Suite Report
+
+```
+base-d benchmark suite
+Platform: x86_64 (AVX2, SSSE3)
+Input: 1 MB random data
+Date: 2025-11-30
+
+┌─────────────────────┬────────┬─────────────┬─────────────┬─────────────┬─────────────┐
+│ Dictionary          │ Base   │ Scalar      │ LUT         │ Specialized │ Streaming   │
+├─────────────────────┼────────┼─────────────┼─────────────┼─────────────┼─────────────┤
+│ base64              │ 64     │ 45.2 MB/s   │ 312 MB/s    │ 1.52 GB/s   │ 1.48 GB/s   │
+│ base64url           │ 64     │ 44.8 MB/s   │ 308 MB/s    │ 1.51 GB/s   │ 1.47 GB/s   │
+│ base32              │ 32     │ 38.1 MB/s   │ 245 MB/s    │ 892 MB/s    │ 875 MB/s    │
+│ base32hex           │ 32     │ 37.9 MB/s   │ 242 MB/s    │ 888 MB/s    │ 871 MB/s    │
+│ base16              │ 16     │ 52.3 MB/s   │ 425 MB/s    │ 1.85 GB/s   │ 1.81 GB/s   │
+│ hex                 │ 16     │ 51.8 MB/s   │ 418 MB/s    │ 1.82 GB/s   │ 1.78 GB/s   │
+│ bioctal             │ 16     │ 50.2 MB/s   │ 412 MB/s    │ -           │ -           │
+│ base256_matrix      │ 256    │ 28.5 MB/s   │ 185 MB/s    │ 725 MB/s    │ 712 MB/s    │
+│ base58              │ 58     │ 12.4 MB/s   │ -           │ -           │ -           │
+│ base85              │ 85     │ 18.2 MB/s   │ -           │ -           │ -           │
+│ cards               │ 52     │ 15.1 MB/s   │ -           │ -           │ -           │
+│ hieroglyphs         │ 100    │ 8.3 MB/s    │ -           │ -           │ -           │
+│ emoji_faces         │ 80     │ 9.1 MB/s    │ -           │ -           │ -           │
+└─────────────────────┴────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+
+Legend:
+  - = Not supported for this dictionary/platform
+  Throughput measured as input bytes processed per second
+```
+
+### Single Dictionary Report
+
+```
+base-d benchmark: base64
+Platform: x86_64 (AVX2, SSSE3)
+
+Encode (1 MB random data, 100 iterations):
+┌─────────────┬────────────┬────────────┬────────────┬────────────┐
+│ Path        │ Mean       │ Std Dev    │ Throughput │ vs Scalar  │
+├─────────────┼────────────┼────────────┼────────────┼────────────┤
+│ Scalar      │ 22.14 ms   │ ±0.31 ms   │ 45.2 MB/s  │ 1.00x      │
+│ LUT         │ 3.21 ms    │ ±0.08 ms   │ 312 MB/s   │ 6.90x      │
+│ Specialized │ 0.66 ms    │ ±0.02 ms   │ 1.52 GB/s  │ 33.5x      │
+│ Streaming   │ 0.68 ms    │ ±0.03 ms   │ 1.48 GB/s  │ 32.6x      │
+└─────────────┴────────────┴────────────┴────────────┴────────────┘
+
+Decode (1 MB encoded data, 100 iterations):
+┌─────────────┬────────────┬────────────┬────────────┬────────────┐
+│ Path        │ Mean       │ Std Dev    │ Throughput │ vs Scalar  │
+├─────────────┼────────────┼────────────┼────────────┼────────────┤
+│ Scalar      │ 25.82 ms   │ ±0.42 ms   │ 38.7 MB/s  │ 1.00x      │
+│ LUT         │ 3.85 ms    │ ±0.11 ms   │ 260 MB/s   │ 6.71x      │
+│ Specialized │ 0.78 ms    │ ±0.03 ms   │ 1.28 GB/s  │ 33.1x      │
+│ Streaming   │ 0.81 ms    │ ±0.04 ms   │ 1.23 GB/s  │ 31.9x      │
+└─────────────┴────────────┴────────────┴────────────┴────────────┘
+```
+
+### Size Scaling Report
+
+```
+base-d benchmark: base64 (size scaling)
+Platform: x86_64 (AVX2)
+Path: Specialized
+
+┌────────────┬────────────┬────────────┬────────────┐
+│ Input Size │ Encode     │ Decode     │ Throughput │
+├────────────┼────────────┼────────────┼────────────┤
+│ 16 B       │ 42 ns      │ 51 ns      │ 380 MB/s   │
+│ 256 B      │ 118 ns     │ 142 ns     │ 2.17 GB/s  │
+│ 1 KB       │ 312 ns     │ 385 ns     │ 3.20 GB/s  │
+│ 16 KB      │ 4.2 µs     │ 5.1 µs     │ 3.81 GB/s  │
+│ 1 MB       │ 0.66 ms    │ 0.78 ms    │ 1.52 GB/s  │
+│ 100 MB     │ 68.2 ms    │ 81.5 ms    │ 1.47 GB/s  │
+└────────────┴────────────┴────────────┴────────────┘
+```
+
+## CLI Interface
+
+```bash
+# Full suite with random data
+base-d bench
+
+# Full suite with specific size
+base-d bench --size 1mb
+
+# Single dictionary
+base-d bench --dict base64
+
+# Custom input file
+base-d bench --input data.bin
+
+# Specific paths only
+base-d bench --dict base64 --paths scalar,specialized
+
+# JSON output for CI
+base-d bench --json > benchmark.json
+
+# Quick mode (fewer iterations)
+base-d bench --quick
+
+# Size scaling test
+base-d bench --dict base64 --scaling
+```
+
+## Implementation
+
+### Path Detection
+
+For each dictionary, detect available paths:
+
+```rust
+struct BenchmarkPaths {
+    scalar: bool,      // Always true
+    lut: bool,         // Power-of-2 base, ASCII chars
+    specialized: bool, // Known RFC dictionary + platform support
+    streaming: bool,   // Chunked mode dictionaries
+}
+
+fn detect_paths(dict: &Dictionary, platform: Platform) -> BenchmarkPaths {
+    // ...
+}
+```
+
+### Platform Detection
+
+```rust
+enum Platform {
+    X86_64 { avx2: bool, ssse3: bool, avx512: bool },
+    Aarch64 { neon: bool },
+    Other,
+}
+```
+
+### Benchmark Runner
+
+```rust
+struct BenchmarkResult {
+    dictionary: String,
+    path: String,
+    operation: Operation, // Encode | Decode
+    input_size: usize,
+    iterations: usize,
+    mean_ns: u64,
+    std_dev_ns: u64,
+    throughput_mbps: f64,
+}
+```

--- a/docs/SIMD_BINARY.md
+++ b/docs/SIMD_BINARY.md
@@ -1,0 +1,70 @@
+# SIMD for Binary Encoding
+
+## Current Status
+
+No SIMD implementation for binary (base-2) encoding.
+
+## Current SIMD Support
+
+| Base | Bits/char | Implementation |
+|------|-----------|----------------|
+| base16 | 4-bit | SmallLutCodec |
+| base32 | 5-bit | Specialized + GappedLutCodec |
+| base64 | 6-bit | Specialized + GappedLutCodec |
+| base256 | 8-bit | Specialized |
+
+## Why Binary SIMD Is Problematic
+
+### The Expansion Problem
+
+Binary encoding has the worst expansion ratio of any base:
+- 1 input byte → 8 output characters
+- 16 bytes (one SIMD register) → 128 output bytes
+- 32 bytes (AVX2 register) → 256 output bytes
+
+Compare to base64:
+- 3 input bytes → 4 output characters (1.33x expansion)
+
+### Memory Bandwidth Dominates
+
+SIMD shines when computation is the bottleneck. With binary:
+1. **Read**: 32 bytes
+2. **Compute**: Extract bits (trivial)
+3. **Write**: 256 bytes
+
+The 8x write amplification means you're memory-bound, not compute-bound.
+
+### Bit Extraction Is Already Fast
+
+Scalar binary encoding is simple:
+```rust
+for byte in data {
+    for i in (0..8).rev() {
+        result.push(if (byte >> i) & 1 == 1 { '1' } else { '0' });
+    }
+}
+```
+
+There's no complex LUT lookup or range validation to accelerate.
+
+### Potential SIMD Approach
+
+If implemented, it would use:
+- `movmskb` / `pmovmskb` to extract bit masks
+- Parallel bit-to-ASCII conversion (`0x30` + bit value)
+- Interleaving for correct output order
+
+But the gains would be marginal due to the expansion ratio.
+
+## Conclusion
+
+SIMD for binary encoding is technically possible but economically poor:
+- The 8x expansion ratio makes it memory-bound
+- Scalar bit shifts are already fast
+- Code complexity isn't justified by performance gains
+
+The current scalar implementation is likely within 2x of theoretical SIMD performance, whereas base64 SIMD provides 4-10x speedup over scalar.
+
+## Future Consideration
+
+If profiling shows binary encoding as a bottleneck in real workloads, revisit this analysis. Until then, scalar is sufficient.

--- a/scripts/bench_summary.py
+++ b/scripts/bench_summary.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Summarize criterion benchmark results."""
+
+import json
+import sys
+from pathlib import Path
+
+CRITERION_DIR = Path("target/criterion")
+
+def get_throughput(mean_ns: float, size_bytes: int) -> tuple[float, str]:
+    """Calculate throughput from mean time. Returns (mb_per_sec, formatted_str)."""
+    seconds = mean_ns / 1_000_000_000
+    mb_per_sec = (size_bytes / seconds) / (1024 * 1024)
+    if mb_per_sec >= 1000:
+        return mb_per_sec, f"{mb_per_sec / 1024:.2f} GB/s"
+    return mb_per_sec, f"{mb_per_sec:.1f} MB/s"
+
+def parse_estimates(path: Path) -> dict | None:
+    """Parse estimates.json file."""
+    try:
+        with open(path / "new" / "estimates.json") as f:
+            data = json.load(f)
+            return {
+                "mean_ns": data["mean"]["point_estimate"],
+                "std_dev_ns": data["std_dev"]["point_estimate"],
+            }
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return None
+
+def summarize_dictionary(group_dir: Path) -> dict:
+    """Summarize results for a dictionary/operation group."""
+    results = {}
+    paths = ["Scalar", "LUT", "Specialized"]
+    sizes = [64, 256, 1024, 4096, 16384, 65536]
+
+    for path in paths:
+        path_dir = group_dir / path
+        if not path_dir.exists():
+            continue
+
+        results[path] = {}
+        for size in sizes:
+            size_dir = path_dir / str(size)
+            if size_dir.exists():
+                estimates = parse_estimates(size_dir)
+                if estimates:
+                    mb_per_sec, formatted = get_throughput(estimates["mean_ns"], size)
+                    results[path][size] = {
+                        **estimates,
+                        "throughput": formatted,
+                        "throughput_mbps": mb_per_sec,
+                    }
+
+    return results
+
+def print_full_table():
+    """Print full benchmark comparison table."""
+    if not CRITERION_DIR.exists():
+        print("No benchmark results found. Run: cargo bench")
+        sys.exit(1)
+
+    groups = sorted(CRITERION_DIR.iterdir())
+
+    # Collect all results
+    all_results = {}
+    for group_dir in groups:
+        if not group_dir.is_dir() or group_dir.name == "report":
+            continue
+        all_results[group_dir.name] = summarize_dictionary(group_dir)
+
+    # Print compact table
+    print("\n" + "=" * 90)
+    print("base-d Benchmark Summary (64KB input)")
+    print("=" * 90)
+    print(f"{'Operation/Dictionary':<25} {'Scalar':<12} {'LUT':<12} {'Specialized':<12} {'Best':<10}")
+    print("-" * 90)
+
+    for name, results in sorted(all_results.items()):
+        if not results:
+            continue
+
+        row = f"{name:<25}"
+        best_path = None
+        best_throughput = 0
+
+        for path in ["Scalar", "LUT", "Specialized"]:
+            if path in results and 65536 in results[path]:
+                tp = results[path][65536]["throughput"]
+                tp_mbps = results[path][65536]["throughput_mbps"]
+                row += f" {tp:<12}"
+                if tp_mbps > best_throughput:
+                    best_throughput = tp_mbps
+                    best_path = path
+            else:
+                row += f" {'-':<12}"
+
+        if best_path:
+            row += f" {best_path}"
+        print(row)
+
+    print("-" * 90)
+
+def print_detailed():
+    """Print detailed per-dictionary summary."""
+    if not CRITERION_DIR.exists():
+        print("No benchmark results found. Run: cargo bench")
+        sys.exit(1)
+
+    groups = sorted(CRITERION_DIR.iterdir())
+
+    print("\n" + "=" * 80)
+    print("base-d Benchmark Results (Detailed)")
+    print("=" * 80)
+
+    for group_dir in groups:
+        if not group_dir.is_dir() or group_dir.name == "report":
+            continue
+
+        print(f"\n{group_dir.name}")
+        print("-" * 60)
+
+        results = summarize_dictionary(group_dir)
+        if not results:
+            print("  No results yet")
+            continue
+
+        # Print table header
+        print(f"  {'Path':<12} {'64B':<10} {'1KB':<10} {'64KB':<10}")
+        print(f"  {'-'*12} {'-'*10} {'-'*10} {'-'*10}")
+
+        for path in ["Scalar", "LUT", "Specialized"]:
+            if path not in results:
+                continue
+
+            row = f"  {path:<12}"
+            for size in [64, 1024, 65536]:
+                if size in results[path]:
+                    tp = results[path][size]["throughput"]
+                    row += f" {tp:<10}"
+                else:
+                    row += f" {'-':<10}"
+            print(row)
+
+        # Calculate speedup
+        if "Scalar" in results and 65536 in results["Scalar"]:
+            scalar_ns = results["Scalar"][65536]["mean_ns"]
+            print(f"\n  Speedup vs Scalar (64KB):")
+            for path in ["LUT", "Specialized"]:
+                if path in results and 65536 in results[path]:
+                    speedup = scalar_ns / results[path][65536]["mean_ns"]
+                    print(f"    {path}: {speedup:.1f}x")
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--detailed":
+        print_detailed()
+    else:
+        print_full_table()

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,510 @@
+//! Benchmarking utilities for comparing encoding paths.
+//!
+//! This module exposes internal encoding paths for performance comparison:
+//! - Scalar: Pure Rust, no SIMD
+//! - LUT: SIMD with runtime lookup tables
+//! - Specialized: Hardcoded SIMD for known dictionaries
+//!
+//! # Example
+//!
+//! ```ignore
+//! use base_d::bench::{EncodingPath, encode_with_path, detect_available_paths};
+//!
+//! let dict = get_dictionary("base64");
+//! let paths = detect_available_paths(&dict);
+//!
+//! for path in paths {
+//!     let result = encode_with_path(data, &dict, path);
+//! }
+//! ```
+
+use crate::EncodingMode;
+use crate::core::dictionary::Dictionary;
+use crate::encoders::algorithms::{DecodeError, byte_range, radix};
+
+#[cfg(feature = "simd")]
+use crate::simd;
+
+/// Available encoding paths for benchmarking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EncodingPath {
+    /// Pure scalar implementation (no SIMD)
+    Scalar,
+    /// SIMD with runtime LUT construction
+    Lut,
+    /// Hardcoded SIMD for known RFC dictionaries
+    Specialized,
+}
+
+impl std::fmt::Display for EncodingPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EncodingPath::Scalar => write!(f, "Scalar"),
+            EncodingPath::Lut => write!(f, "LUT"),
+            EncodingPath::Specialized => write!(f, "Specialized"),
+        }
+    }
+}
+
+/// Platform capabilities for SIMD.
+#[derive(Debug, Clone)]
+pub struct PlatformInfo {
+    pub arch: &'static str,
+    pub simd_features: Vec<&'static str>,
+}
+
+impl PlatformInfo {
+    /// Detect current platform capabilities.
+    pub fn detect() -> Self {
+        let arch = std::env::consts::ARCH;
+        let mut simd_features = Vec::new();
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx512vbmi") {
+                simd_features.push("AVX-512 VBMI");
+            }
+            if is_x86_feature_detected!("avx2") {
+                simd_features.push("AVX2");
+            }
+            if is_x86_feature_detected!("ssse3") {
+                simd_features.push("SSSE3");
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            // NEON is always available on aarch64
+            simd_features.push("NEON");
+        }
+
+        PlatformInfo {
+            arch,
+            simd_features,
+        }
+    }
+
+    /// Format as display string.
+    pub fn display(&self) -> String {
+        if self.simd_features.is_empty() {
+            self.arch.to_string()
+        } else {
+            format!("{} ({})", self.arch, self.simd_features.join(", "))
+        }
+    }
+}
+
+/// Information about a dictionary's benchmark capabilities.
+#[derive(Debug, Clone)]
+pub struct DictionaryBenchInfo {
+    pub name: String,
+    pub base: usize,
+    pub mode: EncodingMode,
+    pub available_paths: Vec<EncodingPath>,
+    pub supports_streaming: bool,
+}
+
+/// Detect which encoding paths are available for a dictionary.
+pub fn detect_available_paths(dict: &Dictionary) -> Vec<EncodingPath> {
+    let mut paths = vec![EncodingPath::Scalar]; // Scalar always available
+
+    #[cfg(feature = "simd")]
+    {
+        let base = dict.base();
+        let mode = dict.mode();
+
+        // Check if LUT path is available (power-of-2 base, ASCII chars)
+        if base.is_power_of_two() && base <= 256 {
+            // Check if all chars are ASCII
+            let all_ascii = (0..base).all(|i| {
+                dict.encode_digit(i)
+                    .map(|c| (c as u32) < 128)
+                    .unwrap_or(false)
+            });
+
+            if all_ascii && matches!(mode, EncodingMode::Chunked) {
+                paths.push(EncodingPath::Lut);
+            }
+        }
+
+        // Check if specialized path is available
+        if is_specialized_available(dict) {
+            paths.push(EncodingPath::Specialized);
+        }
+    }
+
+    paths
+}
+
+/// Check if a specialized SIMD path exists for this dictionary.
+#[cfg(feature = "simd")]
+fn is_specialized_available(dict: &Dictionary) -> bool {
+    use crate::simd::variants::{identify_base32_variant, identify_base64_variant};
+
+    let base = dict.base();
+
+    match base {
+        16 => {
+            // Check if it's standard hex (uppercase or lowercase)
+            let first_char = dict.encode_digit(10); // 'A' or 'a' position
+            matches!(first_char, Some('A') | Some('a'))
+        }
+        32 => identify_base32_variant(dict).is_some(),
+        64 => identify_base64_variant(dict).is_some(),
+        256 => matches!(dict.mode(), EncodingMode::Chunked | EncodingMode::ByteRange),
+        _ => false,
+    }
+}
+
+#[cfg(not(feature = "simd"))]
+fn is_specialized_available(_dict: &Dictionary) -> bool {
+    false
+}
+
+/// Encode using a specific path (for benchmarking).
+///
+/// Returns `None` if the path is not available for this dictionary.
+pub fn encode_with_path(data: &[u8], dict: &Dictionary, path: EncodingPath) -> Option<String> {
+    match path {
+        EncodingPath::Scalar => Some(encode_scalar(data, dict)),
+        EncodingPath::Lut => encode_lut(data, dict),
+        EncodingPath::Specialized => encode_specialized(data, dict),
+    }
+}
+
+/// Decode using a specific path (for benchmarking).
+///
+/// Returns `None` if the path is not available for this dictionary.
+pub fn decode_with_path(encoded: &str, dict: &Dictionary, path: EncodingPath) -> Option<Vec<u8>> {
+    match path {
+        EncodingPath::Scalar => decode_scalar(encoded, dict).ok(),
+        EncodingPath::Lut => decode_lut(encoded, dict),
+        EncodingPath::Specialized => decode_specialized(encoded, dict),
+    }
+}
+
+/// Pure scalar encoding (no SIMD).
+fn encode_scalar(data: &[u8], dict: &Dictionary) -> String {
+    match dict.mode() {
+        EncodingMode::Radix => radix::encode(data, dict),
+        EncodingMode::Chunked => encode_chunked_scalar(data, dict),
+        EncodingMode::ByteRange => byte_range::encode_byte_range(data, dict),
+    }
+}
+
+/// Pure scalar decoding (no SIMD).
+fn decode_scalar(encoded: &str, dict: &Dictionary) -> Result<Vec<u8>, crate::DecodeError> {
+    match dict.mode() {
+        EncodingMode::Radix => radix::decode(encoded, dict),
+        EncodingMode::Chunked => decode_chunked_scalar(encoded, dict),
+        EncodingMode::ByteRange => byte_range::decode_byte_range(encoded, dict),
+    }
+}
+
+/// Scalar chunked encoding (bypasses SIMD).
+fn encode_chunked_scalar(data: &[u8], dict: &Dictionary) -> String {
+    let base = dict.base();
+    let bits_per_char = (base as f64).log2() as usize;
+
+    if bits_per_char == 0 || base & (base - 1) != 0 {
+        // Non-power-of-2, fall back to radix
+        return radix::encode(data, dict);
+    }
+
+    let mut result = String::new();
+    let mut bit_buffer: u64 = 0;
+    let mut bits_in_buffer = 0;
+
+    for &byte in data {
+        bit_buffer = (bit_buffer << 8) | byte as u64;
+        bits_in_buffer += 8;
+
+        while bits_in_buffer >= bits_per_char {
+            bits_in_buffer -= bits_per_char;
+            let index = ((bit_buffer >> bits_in_buffer) & ((1 << bits_per_char) - 1)) as usize;
+            if let Some(ch) = dict.encode_digit(index) {
+                result.push(ch);
+            }
+        }
+    }
+
+    // Handle remaining bits
+    if bits_in_buffer > 0 {
+        let index = ((bit_buffer << (bits_per_char - bits_in_buffer)) & ((1 << bits_per_char) - 1))
+            as usize;
+        if let Some(ch) = dict.encode_digit(index) {
+            result.push(ch);
+        }
+    }
+
+    // Add padding if needed
+    if let Some(pad) = dict.padding() {
+        let output_block_size = match bits_per_char {
+            6 => 4, // base64
+            5 => 8, // base32
+            4 => 2, // base16
+            _ => 1,
+        };
+        while !result.len().is_multiple_of(output_block_size) {
+            result.push(pad);
+        }
+    }
+
+    result
+}
+
+/// Scalar chunked decoding (bypasses SIMD).
+fn decode_chunked_scalar(encoded: &str, dict: &Dictionary) -> Result<Vec<u8>, crate::DecodeError> {
+    let base = dict.base();
+    let bits_per_char = (base as f64).log2() as usize;
+
+    if bits_per_char == 0 || base & (base - 1) != 0 {
+        return radix::decode(encoded, dict);
+    }
+
+    // Strip padding
+    let padding = dict.padding();
+    let encoded = if let Some(pad) = padding {
+        encoded.trim_end_matches(pad)
+    } else {
+        encoded
+    };
+
+    let mut result = Vec::new();
+    let mut bit_buffer: u64 = 0;
+    let mut bits_in_buffer = 0;
+
+    for ch in encoded.chars() {
+        let value = dict.decode_char(ch).ok_or(DecodeError::InvalidCharacter {
+            char: ch,
+            position: 0,
+            input: String::new(),
+            valid_chars: String::new(),
+        })?;
+        bit_buffer = (bit_buffer << bits_per_char) | value as u64;
+        bits_in_buffer += bits_per_char;
+
+        while bits_in_buffer >= 8 {
+            bits_in_buffer -= 8;
+            result.push((bit_buffer >> bits_in_buffer) as u8);
+        }
+    }
+
+    Ok(result)
+}
+
+/// LUT-based SIMD encoding (uses runtime LUT construction, not hardcoded tables).
+#[cfg(feature = "simd")]
+fn encode_lut(data: &[u8], dict: &Dictionary) -> Option<String> {
+    let base = dict.base();
+
+    // Skip specialized paths - force LUT-based codecs only
+    // 1. Try GenericSimdCodec for sequential power-of-2 dictionaries
+    if let Some(codec) = simd::GenericSimdCodec::from_dictionary(dict) {
+        return codec.encode(data, dict);
+    }
+
+    // 2. Try GappedSequentialCodec for near-sequential dictionaries
+    if let Some(codec) = simd::GappedSequentialCodec::from_dictionary(dict) {
+        return codec.encode(data, dict);
+    }
+
+    // 3. Try SmallLutCodec for small arbitrary dictionaries (≤16 chars)
+    if base <= 16
+        && base.is_power_of_two()
+        && let Some(codec) = simd::SmallLutCodec::from_dictionary(dict)
+    {
+        return codec.encode(data, dict);
+    }
+
+    // 4. Try Base64LutCodec for larger arbitrary dictionaries (17-64 chars)
+    if (17..=64).contains(&base)
+        && base.is_power_of_two()
+        && let Some(codec) = simd::Base64LutCodec::from_dictionary(dict)
+    {
+        return codec.encode(data, dict);
+    }
+
+    None
+}
+
+#[cfg(not(feature = "simd"))]
+fn encode_lut(_data: &[u8], _dict: &Dictionary) -> Option<String> {
+    None
+}
+
+/// LUT-based SIMD decoding (uses runtime LUT construction, not hardcoded tables).
+#[cfg(feature = "simd")]
+fn decode_lut(encoded: &str, dict: &Dictionary) -> Option<Vec<u8>> {
+    let base = dict.base();
+
+    // Skip specialized paths - force LUT-based codecs only
+    // 1. Try GenericSimdCodec for sequential power-of-2 dictionaries
+    if let Some(codec) = simd::GenericSimdCodec::from_dictionary(dict) {
+        return codec.decode(encoded, dict);
+    }
+
+    // 2. Try GappedSequentialCodec for near-sequential dictionaries
+    if let Some(codec) = simd::GappedSequentialCodec::from_dictionary(dict) {
+        return codec.decode(encoded, dict);
+    }
+
+    // 3. Try SmallLutCodec for small arbitrary dictionaries (≤16 chars)
+    if base <= 16
+        && base.is_power_of_two()
+        && let Some(codec) = simd::SmallLutCodec::from_dictionary(dict)
+    {
+        return codec.decode(encoded, dict);
+    }
+
+    // 4. Try Base64LutCodec for larger arbitrary dictionaries (17-64 chars)
+    if (17..=64).contains(&base)
+        && base.is_power_of_two()
+        && let Some(codec) = simd::Base64LutCodec::from_dictionary(dict)
+    {
+        return codec.decode(encoded, dict);
+    }
+
+    None
+}
+
+#[cfg(not(feature = "simd"))]
+fn decode_lut(_encoded: &str, _dict: &Dictionary) -> Option<Vec<u8>> {
+    None
+}
+
+/// Specialized SIMD encoding (for known RFC dictionaries).
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+fn encode_specialized(data: &[u8], dict: &Dictionary) -> Option<String> {
+    use crate::simd::{
+        encode_base16_simd, encode_base32_simd, encode_base64_simd, encode_base256_simd,
+    };
+
+    match dict.base() {
+        16 => encode_base16_simd(data, dict),
+        32 => encode_base32_simd(data, dict),
+        64 => encode_base64_simd(data, dict),
+        256 => encode_base256_simd(data, dict),
+        _ => None,
+    }
+}
+
+#[cfg(all(feature = "simd", not(target_arch = "x86_64")))]
+fn encode_specialized(_data: &[u8], _dict: &Dictionary) -> Option<String> {
+    // ARM doesn't have specialized paths yet (uses LUT)
+    None
+}
+
+#[cfg(not(feature = "simd"))]
+fn encode_specialized(_data: &[u8], _dict: &Dictionary) -> Option<String> {
+    None
+}
+
+/// Specialized SIMD decoding (for known RFC dictionaries).
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+fn decode_specialized(encoded: &str, dict: &Dictionary) -> Option<Vec<u8>> {
+    use crate::simd::{
+        decode_base16_simd, decode_base32_simd, decode_base64_simd, decode_base256_simd,
+    };
+
+    match dict.base() {
+        16 => decode_base16_simd(encoded, dict),
+        32 => decode_base32_simd(encoded, dict),
+        64 => decode_base64_simd(encoded, dict),
+        256 => decode_base256_simd(encoded, dict),
+        _ => None,
+    }
+}
+
+#[cfg(all(feature = "simd", not(target_arch = "x86_64")))]
+fn decode_specialized(_encoded: &str, _dict: &Dictionary) -> Option<Vec<u8>> {
+    None
+}
+
+#[cfg(not(feature = "simd"))]
+fn decode_specialized(_encoded: &str, _dict: &Dictionary) -> Option<Vec<u8>> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DictionaryRegistry;
+
+    fn get_test_dict(name: &str) -> Dictionary {
+        let config = DictionaryRegistry::load_default().unwrap();
+        let dict_config = config.get_dictionary(name).unwrap();
+        let chars: Vec<char> = dict_config.effective_chars().unwrap().chars().collect();
+        let padding = dict_config.padding.as_ref().and_then(|s| s.chars().next());
+        let mut builder = Dictionary::builder()
+            .chars(chars)
+            .mode(dict_config.effective_mode());
+        if let Some(p) = padding {
+            builder = builder.padding(p);
+        }
+        builder.build().unwrap()
+    }
+
+    #[test]
+    fn test_platform_detection() {
+        let info = PlatformInfo::detect();
+        assert!(!info.arch.is_empty());
+        println!("Platform: {}", info.display());
+    }
+
+    #[test]
+    fn test_path_detection_base64() {
+        let dict = get_test_dict("base64");
+        let paths = detect_available_paths(&dict);
+
+        assert!(paths.contains(&EncodingPath::Scalar));
+        #[cfg(feature = "simd")]
+        {
+            assert!(
+                paths.contains(&EncodingPath::Lut) || paths.contains(&EncodingPath::Specialized)
+            );
+        }
+    }
+
+    #[test]
+    fn test_scalar_round_trip() {
+        let dict = get_test_dict("base64");
+        let data = b"Hello, World!";
+
+        let encoded = encode_with_path(data, &dict, EncodingPath::Scalar).unwrap();
+        let decoded = decode_with_path(&encoded, &dict, EncodingPath::Scalar).unwrap();
+
+        assert_eq!(&decoded[..], &data[..]);
+    }
+
+    #[test]
+    fn test_paths_produce_same_output() {
+        let dict = get_test_dict("base64");
+        let data = b"The quick brown fox jumps over the lazy dog";
+        let paths = detect_available_paths(&dict);
+
+        let mut results: Vec<(EncodingPath, String)> = Vec::new();
+        for path in &paths {
+            if let Some(encoded) = encode_with_path(data, &dict, *path) {
+                results.push((*path, encoded));
+            }
+        }
+
+        // Compare Scalar with others, stripping padding for fair comparison
+        // (LUT codecs don't add padding, specialized RFC implementations do)
+        let scalar_result = results.iter().find(|(p, _)| *p == EncodingPath::Scalar);
+        if let Some((_, scalar_encoded)) = scalar_result {
+            let scalar_stripped = scalar_encoded.trim_end_matches('=');
+            for (path, encoded) in &results {
+                if *path != EncodingPath::Scalar {
+                    let stripped = encoded.trim_end_matches('=');
+                    assert_eq!(
+                        scalar_stripped, stripped,
+                        "{:?} output differs from Scalar (ignoring padding)",
+                        path
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,8 @@ mod features;
 #[cfg(feature = "simd")]
 mod simd;
 
+pub mod bench;
+
 pub use core::config::{
     CompressionConfig, DictionaryConfig, DictionaryRegistry, EncodingMode, Settings,
 };


### PR DESCRIPTION
## Summary

- Add `src/bench.rs` exposing internal encoding paths (Scalar, LUT, Specialized)
- Add `detect_available_paths()` to identify which paths work for a dictionary
- Add `encode_with_path()`/`decode_with_path()` to force specific SIMD paths
- Expand `benches/encoding.rs` to test all dictionaries across all available paths
- Add `base32_geohash` and `base32_zbase` to test GappedSequentialCodec and Base64LutCodec
- Add `scripts/bench_summary.py` to parse criterion results into tables
- Add `docs/BENCHMARKING.md` with output format spec
- Add `docs/SIMD_BINARY.md` explaining why binary SIMD isn't worthwhile
- Update README with new performance numbers (7.4 GB/s decode, 500 MB/s encode)

## Key Findings

| Operation | Scalar | LUT | Specialized | Speedup |
|-----------|--------|-----|-------------|---------|
| decode_base64 | 151 MB/s | 288 MB/s | **7.36 GB/s** | 50x |
| decode_base32 | 129 MB/s | 267 MB/s | **4.81 GB/s** | 37x |
| encode_base64 | 270 MB/s | 290 MB/s | **495 MB/s** | 1.8x |
| decode_bioctal (LUT) | 109 MB/s | **230 MB/s** | - | 2.1x |
| base58/base85 | ~0.2 MB/s | - | - | n/a (radix) |

LUT decode provides **2.2x speedup** for arbitrary alphabets like zbase/geohash.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo bench --bench encoding` runs successfully
- [x] `python3 scripts/bench_summary.py` parses results

Closes #110