### PR TITLE
feat(api): library ergonomics improvements

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,4 +1,4 @@
-use base_d::{Dictionary, DictionaryRegistry, decode, encode};
+use base_d::{DictionaryRegistry, decode, encode};
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
@@ -216,19 +216,7 @@ pub fn matrix_mode(
 
     loop {
         // Load current dictionary
-        let dictionary_config = config
-            .get_dictionary(&current_dictionary_name)
-            .ok_or(format!("{} dictionary not found", current_dictionary_name))?;
-
-        let chars: Vec<char> = dictionary_config
-            .effective_chars()
-            .map_err(|e| format!("Invalid dictionary config: {}", e))?
-            .chars()
-            .collect();
-        let dictionary = Dictionary::builder()
-            .chars(chars)
-            .mode(dictionary_config.effective_mode())
-            .build()?;
+        let dictionary = create_dictionary(config, &current_dictionary_name)?;
 
         // Check if we need to switch (time-based)
         let should_switch = match &switch_mode {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -36,7 +36,7 @@ pub fn create_dictionary(
         // Try to find a close match
         let available: Vec<String> = config.dictionaries.keys().cloned().collect();
         let suggestion = base_d::find_closest_dictionary(name, &available);
-        base_d::DictionaryNotFoundError::new(name, suggestion)
+        base_d::DictionaryNotFoundError::with_suggestion(name, suggestion)
     })?;
 
     let effective_mode = dictionary_config.effective_mode();

--- a/src/convenience.rs
+++ b/src/convenience.rs
@@ -1,0 +1,157 @@
+//! Convenience functions for common encoding patterns.
+//!
+//! These functions combine hashing/compression with encoding in a single call,
+//! using random dictionary selection for varied output.
+
+use crate::{CompressionAlgorithm, DictionaryRegistry, HashAlgorithm, compress, encode, hash};
+
+/// Result of a hash + encode operation.
+#[derive(Debug, Clone)]
+pub struct HashEncodeResult {
+    /// The encoded output
+    pub encoded: String,
+    /// The hash algorithm used
+    pub hash_algo: HashAlgorithm,
+    /// Name of the dictionary used for encoding
+    pub dictionary_name: String,
+}
+
+/// Result of a compress + encode operation.
+#[derive(Debug, Clone)]
+pub struct CompressEncodeResult {
+    /// The encoded output
+    pub encoded: String,
+    /// The compression algorithm used
+    pub compress_algo: CompressionAlgorithm,
+    /// Name of the dictionary used for encoding
+    pub dictionary_name: String,
+}
+
+/// Hash data with a random algorithm and encode with a random dictionary.
+///
+/// # Example
+/// ```
+/// use base_d::{DictionaryRegistry, convenience::hash_encode};
+///
+/// let registry = DictionaryRegistry::load_default().unwrap();
+/// let result = hash_encode(b"Hello, world!", &registry).unwrap();
+/// println!("Encoded: {}", result.encoded);
+/// println!("Hash: {}", result.hash_algo.as_str());
+/// println!("Dictionary: {}", result.dictionary_name);
+/// ```
+pub fn hash_encode(
+    data: &[u8],
+    registry: &DictionaryRegistry,
+) -> Result<HashEncodeResult, Box<dyn std::error::Error>> {
+    let algo = HashAlgorithm::random();
+    hash_encode_with(data, algo, registry)
+}
+
+/// Hash data with a specific algorithm and encode with a random dictionary.
+pub fn hash_encode_with(
+    data: &[u8],
+    algo: HashAlgorithm,
+    registry: &DictionaryRegistry,
+) -> Result<HashEncodeResult, Box<dyn std::error::Error>> {
+    let hashed = hash(data, algo);
+    let (dict_name, dict) = registry.random()?;
+    let encoded = encode(&hashed, &dict);
+
+    Ok(HashEncodeResult {
+        encoded,
+        hash_algo: algo,
+        dictionary_name: dict_name,
+    })
+}
+
+/// Compress data with a random algorithm and encode with a random dictionary.
+///
+/// # Example
+/// ```
+/// use base_d::{DictionaryRegistry, convenience::compress_encode};
+///
+/// let registry = DictionaryRegistry::load_default().unwrap();
+/// let result = compress_encode(b"Hello, world!", &registry).unwrap();
+/// println!("Encoded: {}", result.encoded);
+/// println!("Compression: {}", result.compress_algo.as_str());
+/// println!("Dictionary: {}", result.dictionary_name);
+/// ```
+pub fn compress_encode(
+    data: &[u8],
+    registry: &DictionaryRegistry,
+) -> Result<CompressEncodeResult, Box<dyn std::error::Error>> {
+    let algo = CompressionAlgorithm::random();
+    compress_encode_with(data, algo, registry)
+}
+
+/// Compress data with a specific algorithm and encode with a random dictionary.
+pub fn compress_encode_with(
+    data: &[u8],
+    algo: CompressionAlgorithm,
+    registry: &DictionaryRegistry,
+) -> Result<CompressEncodeResult, Box<dyn std::error::Error>> {
+    let level = algo.default_level();
+    let compressed = compress(data, algo, level)?;
+    let (dict_name, dict) = registry.random()?;
+    let encoded = encode(&compressed, &dict);
+
+    Ok(CompressEncodeResult {
+        encoded,
+        compress_algo: algo,
+        dictionary_name: dict_name,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_encode() {
+        let registry = DictionaryRegistry::load_default().unwrap();
+        let result = hash_encode(b"test data", &registry).unwrap();
+        assert!(!result.encoded.is_empty());
+        assert!(!result.dictionary_name.is_empty());
+    }
+
+    #[test]
+    fn test_compress_encode() {
+        let registry = DictionaryRegistry::load_default().unwrap();
+        let result = compress_encode(b"test data for compression", &registry).unwrap();
+        assert!(!result.encoded.is_empty());
+        assert!(!result.dictionary_name.is_empty());
+    }
+
+    #[test]
+    fn test_hash_encode_with_specific_algo() {
+        let registry = DictionaryRegistry::load_default().unwrap();
+        let result = hash_encode_with(b"test", HashAlgorithm::Sha256, &registry).unwrap();
+        assert_eq!(result.hash_algo, HashAlgorithm::Sha256);
+    }
+
+    #[test]
+    fn test_compress_encode_with_specific_algo() {
+        let registry = DictionaryRegistry::load_default().unwrap();
+        let result =
+            compress_encode_with(b"test data", CompressionAlgorithm::Gzip, &registry).unwrap();
+        assert_eq!(result.compress_algo, CompressionAlgorithm::Gzip);
+    }
+
+    #[test]
+    fn test_random_hash() {
+        // Just verify it doesn't panic and returns valid algorithms
+        for _ in 0..10 {
+            let algo = HashAlgorithm::random();
+            assert!(HashAlgorithm::all().contains(&algo));
+        }
+    }
+
+    #[test]
+    fn test_random_compress() {
+        // Just verify it doesn't panic and returns valid algorithms
+        for _ in 0..10 {
+            let algo = CompressionAlgorithm::random();
+            assert!(CompressionAlgorithm::all().contains(&algo));
+        }
+    }
+}

--- a/src/encoders/algorithms/errors.rs
+++ b/src/encoders/algorithms/errors.rs
@@ -177,10 +177,24 @@ pub struct DictionaryNotFoundError {
 }
 
 impl DictionaryNotFoundError {
-    pub fn new(name: impl Into<String>, suggestion: Option<String>) -> Self {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            suggestion: None,
+        }
+    }
+
+    pub fn with_suggestion(name: impl Into<String>, suggestion: Option<String>) -> Self {
         Self {
             name: name.into(),
             suggestion,
+        }
+    }
+
+    pub fn with_cause(name: impl Into<String>, cause: impl std::fmt::Display) -> Self {
+        Self {
+            name: name.into(),
+            suggestion: Some(format!("build failed: {}", cause)),
         }
     }
 }
@@ -376,7 +390,7 @@ mod tests {
             std::env::set_var("NO_COLOR", "1");
         }
 
-        let err = DictionaryNotFoundError::new("bas64", Some("base64".to_string()));
+        let err = DictionaryNotFoundError::with_suggestion("bas64", Some("base64".to_string()));
         let display = format!("{}", err);
 
         assert!(display.contains("dictionary 'bas64' not found"));

--- a/src/features/compression.rs
+++ b/src/features/compression.rs
@@ -12,6 +12,37 @@ pub enum CompressionAlgorithm {
 }
 
 impl CompressionAlgorithm {
+    /// Returns all available compression algorithms.
+    pub fn all() -> Vec<CompressionAlgorithm> {
+        vec![
+            CompressionAlgorithm::Gzip,
+            CompressionAlgorithm::Zstd,
+            CompressionAlgorithm::Brotli,
+            CompressionAlgorithm::Lz4,
+            CompressionAlgorithm::Snappy,
+            CompressionAlgorithm::Lzma,
+        ]
+    }
+
+    /// Select a random compression algorithm.
+    pub fn random() -> CompressionAlgorithm {
+        use rand::prelude::IndexedRandom;
+        let all = Self::all();
+        *all.choose(&mut rand::rng()).unwrap()
+    }
+
+    /// Get default compression level for this algorithm.
+    pub fn default_level(&self) -> u32 {
+        match self {
+            CompressionAlgorithm::Gzip => 6,
+            CompressionAlgorithm::Zstd => 3,
+            CompressionAlgorithm::Brotli => 6,
+            CompressionAlgorithm::Lz4 => 0,    // LZ4 ignores level
+            CompressionAlgorithm::Snappy => 0, // Snappy ignores level
+            CompressionAlgorithm::Lzma => 6,
+        }
+    }
+
     /// Parse compression algorithm from string.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self, String> {

--- a/src/features/hashing.rs
+++ b/src/features/hashing.rs
@@ -71,6 +71,43 @@ pub enum HashAlgorithm {
 }
 
 impl HashAlgorithm {
+    /// Returns all available hash algorithms.
+    pub fn all() -> Vec<HashAlgorithm> {
+        vec![
+            HashAlgorithm::Md5,
+            HashAlgorithm::Sha224,
+            HashAlgorithm::Sha256,
+            HashAlgorithm::Sha384,
+            HashAlgorithm::Sha512,
+            HashAlgorithm::Sha3_224,
+            HashAlgorithm::Sha3_256,
+            HashAlgorithm::Sha3_384,
+            HashAlgorithm::Sha3_512,
+            HashAlgorithm::Keccak224,
+            HashAlgorithm::Keccak256,
+            HashAlgorithm::Keccak384,
+            HashAlgorithm::Keccak512,
+            HashAlgorithm::Blake2b,
+            HashAlgorithm::Blake2s,
+            HashAlgorithm::Blake3,
+            HashAlgorithm::Crc32,
+            HashAlgorithm::Crc32c,
+            HashAlgorithm::Crc16,
+            HashAlgorithm::Crc64,
+            HashAlgorithm::XxHash32,
+            HashAlgorithm::XxHash64,
+            HashAlgorithm::XxHash3_64,
+            HashAlgorithm::XxHash3_128,
+        ]
+    }
+
+    /// Select a random hash algorithm.
+    pub fn random() -> HashAlgorithm {
+        use rand::prelude::IndexedRandom;
+        let all = Self::all();
+        *all.choose(&mut rand::rng()).unwrap()
+    }
+
     /// Parse hash algorithm from string.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,13 @@ mod features;
 mod simd;
 
 pub mod bench;
+pub mod convenience;
+pub mod prelude;
 
+pub use convenience::{
+    CompressEncodeResult, HashEncodeResult, compress_encode, compress_encode_with, hash_encode,
+    hash_encode_with,
+};
 pub use core::config::{
     CompressionConfig, DictionaryConfig, DictionaryRegistry, EncodingMode, Settings,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,46 @@
+//! Convenient re-exports for common usage.
+//!
+//! This module provides a single import for the most commonly used types
+//! and functions in base-d.
+//!
+//! # Example
+//!
+//! ```
+//! use base_d::prelude::*;
+//!
+//! let registry = DictionaryRegistry::load_default().unwrap();
+//! let result = hash_encode(b"Hello", &registry).unwrap();
+//! println!("{}", result.encoded);
+//! ```
+
+pub use crate::{
+    CompressionAlgorithm,
+
+    DecodeError,
+    Dictionary,
+    // Detection
+    DictionaryDetector,
+    DictionaryMatch,
+
+    DictionaryRegistry,
+
+    // Config
+    EncodingMode,
+    // Feature types
+    HashAlgorithm,
+    compress,
+    // Convenience functions
+    convenience::{
+        CompressEncodeResult, HashEncodeResult, compress_encode, compress_encode_with, hash_encode,
+        hash_encode_with,
+    },
+
+    decode,
+    decompress,
+    detect_dictionary,
+
+    // Core encoding/decoding
+    encode,
+    // Lower-level functions if needed
+    hash,
+};


### PR DESCRIPTION
## Summary
Implements #115 - Library API ergonomics improvements to enable mx (and other tools) to use base-d as a library instead of shelling out to the CLI.

### Phase 1: Registry Convenience Methods
- `DictionaryRegistry::dictionary(name)` - One-liner to get a ready-to-use Dictionary
- `DictionaryRegistry::random()` - Get a random common dictionary (for dejavu behavior)
- `DictionaryRegistry::names()` / `common_names()` - List available dictionaries

### Phase 2: High-Level Encode Functions
- `hash_encode()` / `hash_encode_with()` - Hash data with (random/specific) algorithm, encode with random dictionary
- `compress_encode()` / `compress_encode_with()` - Compress data, encode with random dictionary
- `HashAlgorithm::random()` / `CompressionAlgorithm::random()` - Random algorithm selection
- `CompressionAlgorithm::default_level()` - Sensible compression level defaults

### Phase 3: Prelude Module
- `use base_d::prelude::*;` for convenient imports

## Target Usage
```rust
use base_d::prelude::*;

let registry = DictionaryRegistry::load_default()?;
let result = hash_encode(b"Hello", &registry)?;
// result.encoded, result.hash_algo, result.dictionary_name
```

## Test Plan
- [x] All existing tests pass (279 unit + 25 integration + 13 doc)
- [ ] Refactor mx to use library instead of CLI subprocess