### PR TITLE
feat: minified fiche output

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -222,6 +222,10 @@ pub struct FicheArgs {
     #[arg(short = 'p', long)]
     pub pretty: bool,
 
+    /// Minify output to single line (encode only)
+    #[arg(short = 'm', long)]
+    pub minify: bool,
+
     /// Output file (writes to stdout if not provided)
     #[arg(short = 'o', long)]
     pub output: Option<PathBuf>,

--- a/src/cli/handlers/fiche.rs
+++ b/src/cli/handlers/fiche.rs
@@ -1,5 +1,5 @@
 use crate::cli::{args::FicheArgs, global::GlobalArgs};
-use base_d::{DictionaryRegistry, decode_fiche, encode_fiche};
+use base_d::{DictionaryRegistry, decode_fiche, encode_fiche, encode_fiche_minified};
 use std::fs;
 use std::io::{self, Read};
 
@@ -21,6 +21,9 @@ pub fn handle(
     let output = if args.decode {
         // Fiche → JSON
         decode_fiche(input_text.trim(), args.pretty)?
+    } else if args.minify {
+        // JSON → Fiche (minified single line)
+        encode_fiche_minified(input_text.trim())?
     } else {
         // JSON → Fiche
         encode_fiche(input_text.trim())?

--- a/src/encoders/algorithms/schema/mod.rs
+++ b/src/encoders/algorithms/schema/mod.rs
@@ -156,10 +156,22 @@ pub fn decode_schema(encoded: &str, pretty: bool) -> Result<String, SchemaError>
 /// // ◉1┃alice
 /// ```
 pub fn encode_fiche(json: &str) -> Result<String, SchemaError> {
+    encode_fiche_with_options(json, false)
+}
+
+pub fn encode_fiche_minified(json: &str) -> Result<String, SchemaError> {
+    encode_fiche_with_options(json, true)
+}
+
+fn encode_fiche_with_options(json: &str, minify: bool) -> Result<String, SchemaError> {
     use parsers::{InputParser, JsonParser};
 
     let ir = JsonParser::parse(json)?;
-    fiche::serialize(&ir)
+    if minify {
+        fiche::serialize_minified(&ir)
+    } else {
+        fiche::serialize(&ir)
+    }
 }
 
 /// Decode fiche format to JSON: fiche → IR → JSON

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,8 @@ pub use encoders::streaming::{StreamingDecoder, StreamingEncoder};
 
 // Expose schema encoding functions for CLI
 pub use encoders::algorithms::schema::{
-    SchemaCompressionAlgo, decode_fiche, decode_schema, encode_fiche, encode_schema,
+    SchemaCompressionAlgo, decode_fiche, decode_schema, encode_fiche, encode_fiche_minified,
+    encode_schema,
 };
 
 /// Schema encoding types and traits for building custom frontends


### PR DESCRIPTION
Uses `▓` as line separator instead of newlines, producing a single unbroken string.

**Normal:**
```
@users┃id:int┃name:str
◉1┃alice
◉2┃bob
```

**Minified (-m):**
```
@users┃id:int┃name:str▓◉1┃alice▓◉2┃bob
```

Survives terminal paste, copy buffers, streaming - no whitespace mangling.

- CLI: `base-d fiche -m`
- API: `encode_fiche_minified()`
- Parser handles both formats transparently