### PR TITLE
Add fiche markdown mode for token-efficient document encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ ascon-hash = "0.3.1"
 k12 = "0.2.1"
 hex = "0.4.3"
 shellexpand = "3.1"
+markdown = "1.0.0-alpha.21"
 
 [dev-dependencies]
 criterion = { version = "0.7", features = ["html_reports"] }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -208,10 +208,10 @@ pub enum ConfigCategory {
     Hashes,
 }
 
-/// Tokenization levels for fiche encoding
+/// Fiche encoding modes
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
-pub enum FicheLevel {
-    /// Auto-detect best mode based on JSON structure
+pub enum FicheMode {
+    /// Auto-detect best mode based on input structure
     #[default]
     Auto,
     /// No tokenization - human readable field names
@@ -222,6 +222,10 @@ pub enum FicheLevel {
     Full,
     /// Path mode - one line per leaf value with full path
     Path,
+    /// ASCII mode - inline CSV-like format with value dictionary (best for JSON)
+    Ascii,
+    /// Markdown-like inline format (best for markdown input)
+    Markdown,
 }
 
 /// Arguments for fiche encoding/decoding (model-readable format)
@@ -231,9 +235,9 @@ pub struct FicheArgs {
     pub command: Option<FicheCommand>,
 
     // Top-level args for implicit encode
-    /// Tokenization level
+    /// Encoding mode
     #[arg(short, long)]
-    pub level: Option<FicheLevel>,
+    pub mode: Option<FicheMode>,
 
     /// Output file (writes to stdout if not provided)
     #[arg(short, long)]
@@ -245,6 +249,10 @@ pub struct FicheArgs {
     /// Use multiline output format
     #[arg(long)]
     pub multiline: bool,
+
+    /// Parse input as markdown document instead of JSON
+    #[arg(long)]
+    pub markdown: bool,
 }
 
 /// Fiche subcommands
@@ -259,9 +267,9 @@ pub enum FicheCommand {
 /// Arguments for fiche encoding
 #[derive(Args, Debug)]
 pub struct FicheEncodeArgs {
-    /// Tokenization level
+    /// Encoding mode
     #[arg(short, long, default_value = "auto")]
-    pub level: FicheLevel,
+    pub mode: FicheMode,
 
     /// Output file (writes to stdout if not provided)
     #[arg(short, long)]
@@ -273,6 +281,10 @@ pub struct FicheEncodeArgs {
     /// Use multiline output format
     #[arg(long)]
     pub multiline: bool,
+
+    /// Parse input as markdown document instead of JSON
+    #[arg(long)]
+    pub markdown: bool,
 }
 
 /// Arguments for fiche decoding

--- a/src/encoders/algorithms/schema/parsers/markdown.rs
+++ b/src/encoders/algorithms/schema/parsers/markdown.rs
@@ -1,0 +1,422 @@
+use crate::encoders::algorithms::schema::parsers::InputParser;
+use crate::encoders::algorithms::schema::types::*;
+
+pub struct MarkdownParser;
+
+impl InputParser for MarkdownParser {
+    type Error = SchemaError;
+
+    fn parse(input: &str) -> Result<IntermediateRepresentation, Self::Error> {
+        // Split input into lines
+        let lines: Vec<&str> = input.lines().collect();
+
+        if lines.is_empty() {
+            return Err(SchemaError::InvalidInput(
+                "Empty markdown table - no content to parse.".to_string(),
+            ));
+        }
+
+        if lines.len() < 2 {
+            return Err(SchemaError::InvalidInput(
+                "Invalid markdown table - requires header row and separator row.".to_string(),
+            ));
+        }
+
+        // Parse header row (first line)
+        let header_row = lines[0];
+        let field_names = parse_table_row(header_row)?;
+
+        if field_names.is_empty() {
+            return Err(SchemaError::InvalidInput(
+                "Empty header row - no field names found.".to_string(),
+            ));
+        }
+
+        // Validate separator row (second line)
+        let separator_row = lines[1];
+        validate_separator_row(separator_row, field_names.len())?;
+
+        // Parse data rows (remaining lines)
+        let data_rows: Vec<Vec<String>> = lines[2..]
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| parse_table_row(line))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if data_rows.is_empty() {
+            return Err(SchemaError::InvalidInput(
+                "Empty table - no data rows found after header and separator.".to_string(),
+            ));
+        }
+
+        let row_count = data_rows.len();
+
+        // Infer field types from data
+        let mut fields = Vec::new();
+        let mut has_nulls = false;
+
+        for (field_idx, field_name) in field_names.iter().enumerate() {
+            let field_type = infer_column_type(&data_rows, field_idx, &mut has_nulls)?;
+            fields.push(FieldDef::new(field_name.clone(), field_type));
+        }
+
+        // Build values and null bitmap
+        let mut values = Vec::new();
+        let total_values = row_count * fields.len();
+        let bitmap_bytes = total_values.div_ceil(8);
+        let mut null_bitmap = vec![0u8; bitmap_bytes];
+
+        for (row_idx, row) in data_rows.iter().enumerate() {
+            for (field_idx, field) in fields.iter().enumerate() {
+                let value_idx = row_idx * fields.len() + field_idx;
+
+                // Get cell value, treating missing cells as empty string
+                let cell = row.get(field_idx).map(|s| s.as_str()).unwrap_or("");
+
+                // Empty cells are null
+                if cell.is_empty() {
+                    values.push(SchemaValue::Null);
+                    set_null_bit(&mut null_bitmap, value_idx);
+                    has_nulls = true;
+                } else {
+                    // Parse value according to field type
+                    values.push(parse_cell_value(cell, &field.field_type)?);
+                }
+            }
+        }
+
+        // Build header
+        let mut header = SchemaHeader::new(row_count, fields);
+        if has_nulls {
+            header.null_bitmap = Some(null_bitmap);
+            header.set_flag(FLAG_HAS_NULLS);
+        }
+
+        IntermediateRepresentation::new(header, values)
+    }
+}
+
+/// Parse a markdown table row into cells
+fn parse_table_row(line: &str) -> Result<Vec<String>, SchemaError> {
+    let trimmed = line.trim();
+
+    // Remove leading and trailing pipe
+    let without_pipes = trimmed
+        .strip_prefix('|')
+        .unwrap_or(trimmed)
+        .strip_suffix('|')
+        .unwrap_or(trimmed);
+
+    // Split by pipe and trim each cell
+    let cells: Vec<String> = without_pipes
+        .split('|')
+        .map(|cell| cell.trim().to_string())
+        .collect();
+
+    Ok(cells)
+}
+
+/// Validate the separator row has correct format
+fn validate_separator_row(line: &str, expected_columns: usize) -> Result<(), SchemaError> {
+    let cells = parse_table_row(line)?;
+
+    if cells.len() != expected_columns {
+        return Err(SchemaError::InvalidInput(format!(
+            "Separator row has {} columns but header has {}.",
+            cells.len(),
+            expected_columns
+        )));
+    }
+
+    // Check each cell is a valid separator (dashes with optional colons)
+    for (idx, cell) in cells.iter().enumerate() {
+        if !is_valid_separator_cell(cell) {
+            return Err(SchemaError::InvalidInput(format!(
+                "Invalid separator cell at column {}: '{}'. Expected dashes (---) with optional colons for alignment.",
+                idx + 1,
+                cell
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if a cell is a valid separator (dashes with optional colons)
+fn is_valid_separator_cell(cell: &str) -> bool {
+    if cell.is_empty() {
+        return false;
+    }
+
+    // Valid patterns: ---, :---, ---:, :---:
+    // Must have at least one dash
+    let has_dash = cell.chars().any(|c| c == '-');
+    let all_valid_chars = cell.chars().all(|c| c == '-' || c == ':');
+
+    has_dash && all_valid_chars
+}
+
+/// Infer the type of a column from all its values
+fn infer_column_type(
+    rows: &[Vec<String>],
+    column_idx: usize,
+    has_nulls: &mut bool,
+) -> Result<FieldType, SchemaError> {
+    let mut inferred_type: Option<FieldType> = None;
+
+    for row in rows {
+        let cell = row.get(column_idx).map(|s| s.as_str()).unwrap_or("");
+
+        // Skip empty cells (they're nulls)
+        if cell.is_empty() {
+            *has_nulls = true;
+            continue;
+        }
+
+        let cell_type = infer_cell_type(cell);
+
+        if let Some(ref existing_type) = inferred_type {
+            // Special case: U64 and I64 unify to I64
+            if (*existing_type == FieldType::U64 && cell_type == FieldType::I64)
+                || (*existing_type == FieldType::I64 && cell_type == FieldType::U64)
+            {
+                inferred_type = Some(FieldType::I64);
+                continue;
+            }
+
+            if *existing_type != cell_type {
+                // Type conflict - use Any
+                return Ok(FieldType::Any);
+            }
+        } else {
+            inferred_type = Some(cell_type);
+        }
+    }
+
+    Ok(inferred_type.unwrap_or(FieldType::Null))
+}
+
+/// Infer the type of a single cell value
+fn infer_cell_type(cell: &str) -> FieldType {
+    // Try boolean (case-insensitive)
+    let lower = cell.to_lowercase();
+    if lower == "true" || lower == "false" {
+        return FieldType::Bool;
+    }
+
+    // Try integer
+    if let Ok(num) = cell.parse::<i64>() {
+        return if num < 0 {
+            FieldType::I64
+        } else {
+            FieldType::U64
+        };
+    }
+
+    // Try float
+    if cell.parse::<f64>().is_ok() {
+        return FieldType::F64;
+    }
+
+    // Default to string
+    FieldType::String
+}
+
+/// Parse a cell value according to its expected type
+fn parse_cell_value(cell: &str, field_type: &FieldType) -> Result<SchemaValue, SchemaError> {
+    match field_type {
+        FieldType::Bool => {
+            let lower = cell.to_lowercase();
+            if lower == "true" {
+                Ok(SchemaValue::Bool(true))
+            } else if lower == "false" {
+                Ok(SchemaValue::Bool(false))
+            } else {
+                Err(SchemaError::InvalidInput(format!(
+                    "Invalid boolean value: '{}'. Expected 'true' or 'false'.",
+                    cell
+                )))
+            }
+        }
+        FieldType::U64 => {
+            let num = cell.parse::<u64>().map_err(|_| {
+                SchemaError::InvalidInput(format!(
+                    "Invalid unsigned integer: '{}'. Value must be a non-negative integer.",
+                    cell
+                ))
+            })?;
+            Ok(SchemaValue::U64(num))
+        }
+        FieldType::I64 => {
+            let num = cell.parse::<i64>().map_err(|_| {
+                SchemaError::InvalidInput(format!(
+                    "Invalid signed integer: '{}'. Value must be an integer.",
+                    cell
+                ))
+            })?;
+            Ok(SchemaValue::I64(num))
+        }
+        FieldType::F64 => {
+            let num = cell.parse::<f64>().map_err(|_| {
+                SchemaError::InvalidInput(format!(
+                    "Invalid floating-point number: '{}'. Value must be a number.",
+                    cell
+                ))
+            })?;
+            Ok(SchemaValue::F64(num))
+        }
+        FieldType::String => Ok(SchemaValue::String(cell.to_string())),
+        FieldType::Any => {
+            // Try to infer and parse
+            let inferred = infer_cell_type(cell);
+            parse_cell_value(cell, &inferred)
+        }
+        FieldType::Null => Ok(SchemaValue::Null),
+        _ => Err(SchemaError::InvalidInput(format!(
+            "Unsupported field type for markdown parsing: {}",
+            field_type.display_name()
+        ))),
+    }
+}
+
+/// Set a bit in the null bitmap
+fn set_null_bit(bitmap: &mut [u8], index: usize) {
+    let byte_idx = index / 8;
+    let bit_idx = index % 8;
+    bitmap[byte_idx] |= 1 << bit_idx;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_table() {
+        let input = r#"| id | name  | grade |
+|----| ----- |-------|
+| A1 | alice | 95    |
+| B2 | bob   | 87    |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 2);
+        assert_eq!(ir.header.fields.len(), 3);
+        assert_eq!(ir.header.fields[0].name, "id");
+        assert_eq!(ir.header.fields[1].name, "name");
+        assert_eq!(ir.header.fields[2].name, "grade");
+    }
+
+    #[test]
+    fn test_type_inference() {
+        let input = r#"| int | float | bool | str |
+|----|-------|------|-----|
+| 42 | 3.14  | true | foo |
+| -1 | 2.0   | false| bar |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.fields[0].field_type, FieldType::I64); // Has negative
+        assert_eq!(ir.header.fields[1].field_type, FieldType::F64);
+        assert_eq!(ir.header.fields[2].field_type, FieldType::Bool);
+        assert_eq!(ir.header.fields[3].field_type, FieldType::String);
+    }
+
+    #[test]
+    fn test_positive_integers() {
+        let input = r#"| count |
+|-------|
+| 1     |
+| 100   |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.fields[0].field_type, FieldType::U64);
+    }
+
+    #[test]
+    fn test_empty_cells() {
+        let input = r#"| name | age |
+|------|-----|
+| alice|     |
+|      | 30  |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert!(ir.header.has_flag(FLAG_HAS_NULLS));
+        assert!(ir.is_null(0, 1)); // age is null in first row
+        assert!(ir.is_null(1, 0)); // name is null in second row
+    }
+
+    #[test]
+    fn test_alignment_markers() {
+        let input = r#"| left | center | right |
+|:-----|:------:|------:|
+| a    | b      | c     |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(ir.header.fields.len(), 3);
+    }
+
+    #[test]
+    fn test_empty_table() {
+        let input = r#"| id | name |
+|----|------|"#;
+
+        let result = MarkdownParser::parse(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_separator() {
+        let input = r#"| id | name |
+| XX | YY   |
+| A1 | alice|"#;
+
+        let result = MarkdownParser::parse(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_cells() {
+        let input = r#"| a | b | c |
+|---|---|---|
+| 1 | 2 |
+| 4 | 5 | 6 |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        // First row, third column should be null
+        assert!(ir.is_null(0, 2));
+    }
+
+    #[test]
+    fn test_single_row() {
+        let input = r#"| id |
+|----|
+| 42 |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(ir.header.fields.len(), 1);
+        assert_eq!(ir.get_value(0, 0), Some(&SchemaValue::U64(42)));
+    }
+
+    #[test]
+    fn test_case_insensitive_bool() {
+        let input = r#"| flag |
+|------|
+| TRUE |
+| False|
+| true |"#;
+
+        let ir = MarkdownParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.fields[0].field_type, FieldType::Bool);
+        assert_eq!(ir.get_value(0, 0), Some(&SchemaValue::Bool(true)));
+        assert_eq!(ir.get_value(1, 0), Some(&SchemaValue::Bool(false)));
+        assert_eq!(ir.get_value(2, 0), Some(&SchemaValue::Bool(true)));
+    }
+}

--- a/src/encoders/algorithms/schema/parsers/markdown_doc.rs
+++ b/src/encoders/algorithms/schema/parsers/markdown_doc.rs
@@ -1,0 +1,623 @@
+use crate::encoders::algorithms::schema::parsers::InputParser;
+use crate::encoders::algorithms::schema::types::*;
+use markdown::mdast::{Blockquote, Code, Heading, List, ListItem, Node, Table};
+use markdown::{Constructs, ParseOptions, to_mdast};
+
+pub struct MarkdownDocParser;
+
+impl InputParser for MarkdownDocParser {
+    type Error = SchemaError;
+
+    fn parse(input: &str) -> Result<IntermediateRepresentation, Self::Error> {
+        // Parse markdown to mdast with GFM (GitHub Flavored Markdown) for tables
+        let options = ParseOptions {
+            constructs: Constructs::gfm(),
+            ..Default::default()
+        };
+
+        let mdast = to_mdast(input, &options)
+            .map_err(|e| SchemaError::InvalidInput(format!("Failed to parse markdown: {}", e)))?;
+
+        // Walk tree and collect blocks
+        let blocks = extract_blocks(&mdast)?;
+
+        if blocks.is_empty() {
+            return Err(SchemaError::InvalidInput(
+                "No content blocks found in markdown document.".to_string(),
+            ));
+        }
+
+        // Build IR schema: type, content, meta
+        let fields = vec![
+            FieldDef::new("type", FieldType::String),
+            FieldDef::new("content", FieldType::String),
+            FieldDef::new("meta", FieldType::String),
+        ];
+
+        let row_count = blocks.len();
+        let mut header = SchemaHeader::new(row_count, fields);
+
+        // Track nulls in meta column
+        let mut has_nulls = false;
+        let total_values = row_count * 3;
+        let bitmap_bytes = total_values.div_ceil(8);
+        let mut null_bitmap = vec![0u8; bitmap_bytes];
+
+        let mut values = Vec::with_capacity(total_values);
+
+        for (idx, block) in blocks.iter().enumerate() {
+            // type
+            values.push(SchemaValue::String(block.block_type.clone()));
+
+            // content
+            values.push(SchemaValue::String(block.content.clone()));
+
+            // meta (nullable)
+            if let Some(meta) = &block.meta {
+                values.push(SchemaValue::String(meta.clone()));
+            } else {
+                values.push(SchemaValue::Null);
+                let meta_idx = idx * 3 + 2; // meta is third column
+                set_null_bit(&mut null_bitmap, meta_idx);
+                has_nulls = true;
+            }
+        }
+
+        if has_nulls {
+            header.null_bitmap = Some(null_bitmap);
+            header.set_flag(FLAG_HAS_NULLS);
+        }
+
+        IntermediateRepresentation::new(header, values)
+    }
+}
+
+/// Simplified block representation
+#[derive(Debug)]
+struct Block {
+    block_type: String,
+    content: String,
+    meta: Option<String>,
+}
+
+impl Block {
+    fn new(block_type: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            block_type: block_type.into(),
+            content: content.into(),
+            meta: None,
+        }
+    }
+
+    fn with_meta(
+        block_type: impl Into<String>,
+        content: impl Into<String>,
+        meta: impl Into<String>,
+    ) -> Self {
+        Self {
+            block_type: block_type.into(),
+            content: content.into(),
+            meta: Some(meta.into()),
+        }
+    }
+}
+
+/// Extract blocks from mdast
+fn extract_blocks(node: &Node) -> Result<Vec<Block>, SchemaError> {
+    let mut blocks = Vec::new();
+    walk_node(node, &mut blocks)?;
+    Ok(blocks)
+}
+
+/// Recursively walk mdast nodes
+fn walk_node(node: &Node, blocks: &mut Vec<Block>) -> Result<(), SchemaError> {
+    match node {
+        Node::Root(root) => {
+            for child in &root.children {
+                walk_node(child, blocks)?;
+            }
+        }
+        Node::Heading(heading) => {
+            blocks.push(heading_to_block(heading)?);
+        }
+        Node::Paragraph(para) => {
+            let text = extract_text(&Node::Paragraph(para.clone()));
+            if !text.trim().is_empty() {
+                blocks.push(Block::new("p", text));
+            }
+        }
+        Node::List(list) => {
+            blocks.push(list_to_block(list)?);
+        }
+        Node::Code(code) => {
+            blocks.push(code_to_block(code));
+        }
+        Node::Blockquote(quote) => {
+            blocks.push(quote_to_block(quote)?);
+        }
+        Node::Table(table) => {
+            blocks.push(table_to_block(table)?);
+        }
+        Node::ThematicBreak(_) => {
+            blocks.push(Block::new("hr", ""));
+        }
+        Node::Link(link) => {
+            let text = extract_text(&Node::Link(link.clone()));
+            blocks.push(Block::with_meta("link", text, &link.url));
+        }
+        Node::Image(img) => {
+            blocks.push(Block::with_meta("image", &img.alt, &img.url));
+        }
+        // Container nodes - recurse into children
+        Node::ListItem(item) => {
+            for child in &item.children {
+                walk_node(child, blocks)?;
+            }
+        }
+        Node::TableRow(_) | Node::TableCell(_) => {
+            // Handled by table_to_block
+        }
+        // Inline nodes and other types - skip, they're handled by text extraction
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Convert heading to block
+fn heading_to_block(heading: &Heading) -> Result<Block, SchemaError> {
+    let level = heading.depth;
+    let block_type = format!("h{}", level);
+    let content = extract_text(&Node::Heading(heading.clone()));
+    Ok(Block::new(block_type, content))
+}
+
+/// Convert list to block
+fn list_to_block(list: &List) -> Result<Block, SchemaError> {
+    let block_type = if list.ordered { "ol" } else { "ul" };
+    let mut items = Vec::new();
+
+    for child in &list.children {
+        if let Node::ListItem(item) = child {
+            let item_text = list_item_to_text(item, 0);
+            items.push(item_text);
+        }
+    }
+
+    let content = items.join(";");
+    Ok(Block::new(block_type, content))
+}
+
+/// Extract list item text with nested lists
+fn list_item_to_text(item: &ListItem, depth: usize) -> String {
+    let mut parts = Vec::new();
+    let indent = "  ".repeat(depth);
+
+    for child in &item.children {
+        match child {
+            Node::Paragraph(para) => {
+                let text = extract_text(&Node::Paragraph(para.clone()));
+                parts.push(format!("{}{}", indent, text.trim()));
+            }
+            Node::List(nested_list) => {
+                for nested_child in &nested_list.children {
+                    if let Node::ListItem(nested_item) = nested_child {
+                        parts.push(list_item_to_text(nested_item, depth + 1));
+                    }
+                }
+            }
+            _ => {
+                let text = extract_text(child);
+                if !text.trim().is_empty() {
+                    parts.push(format!("{}{}", indent, text.trim()));
+                }
+            }
+        }
+    }
+
+    parts.join("\n")
+}
+
+/// Convert code block to block
+fn code_to_block(code: &Code) -> Block {
+    let lang = code.lang.as_deref().unwrap_or("");
+    if lang.is_empty() {
+        Block::new("code", &code.value)
+    } else {
+        Block::with_meta("code", &code.value, lang)
+    }
+}
+
+/// Convert blockquote to block
+fn quote_to_block(quote: &Blockquote) -> Result<Block, SchemaError> {
+    let mut parts = Vec::new();
+    for child in &quote.children {
+        let text = extract_text(child);
+        if !text.trim().is_empty() {
+            parts.push(text);
+        }
+    }
+    Ok(Block::new("quote", parts.join("\n")))
+}
+
+/// Convert table to block
+fn table_to_block(table: &Table) -> Result<Block, SchemaError> {
+    let mut rows = Vec::new();
+
+    for row_node in &table.children {
+        if let Node::TableRow(row) = row_node {
+            let mut cells = Vec::new();
+            for cell_node in &row.children {
+                if let Node::TableCell(cell) = cell_node {
+                    let text = extract_text(&Node::TableCell(cell.clone()));
+                    cells.push(text);
+                }
+            }
+            rows.push(cells.join(","));
+        }
+    }
+
+    let content = rows.join(";");
+    let meta = format!(
+        "{}x{}",
+        rows.len(),
+        table
+            .children
+            .first()
+            .and_then(|r| if let Node::TableRow(row) = r {
+                Some(row.children.len())
+            } else {
+                None
+            })
+            .unwrap_or(0)
+    );
+
+    Ok(Block::with_meta("table", content, meta))
+}
+
+/// Extract plain text from any node (handles inline formatting)
+fn extract_text(node: &Node) -> String {
+    match node {
+        Node::Text(text) => text.value.clone(),
+        Node::InlineCode(code) => format!("`{}`", code.value),
+        Node::Emphasis(em) => {
+            let inner = em
+                .children
+                .iter()
+                .map(extract_text)
+                .collect::<Vec<_>>()
+                .join("");
+            format!("*{}*", inner)
+        }
+        Node::Strong(strong) => {
+            let inner = strong
+                .children
+                .iter()
+                .map(extract_text)
+                .collect::<Vec<_>>()
+                .join("");
+            format!("**{}**", inner)
+        }
+        Node::Link(link) => {
+            let text = link
+                .children
+                .iter()
+                .map(extract_text)
+                .collect::<Vec<_>>()
+                .join("");
+            format!("[{}]({})", text, link.url)
+        }
+        Node::Image(img) => {
+            format!("![{}]({})", img.alt, img.url)
+        }
+        Node::Break(_) => " ".to_string(),
+        Node::Paragraph(para) => para
+            .children
+            .iter()
+            .map(extract_text)
+            .collect::<Vec<_>>()
+            .join(""),
+        Node::Heading(heading) => heading
+            .children
+            .iter()
+            .map(extract_text)
+            .collect::<Vec<_>>()
+            .join(""),
+        Node::TableCell(cell) => cell
+            .children
+            .iter()
+            .map(extract_text)
+            .collect::<Vec<_>>()
+            .join(""),
+        Node::ListItem(item) => item
+            .children
+            .iter()
+            .map(extract_text)
+            .collect::<Vec<_>>()
+            .join(""),
+        Node::Blockquote(quote) => quote
+            .children
+            .iter()
+            .map(extract_text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Node::Delete(del) => {
+            let inner = del
+                .children
+                .iter()
+                .map(extract_text)
+                .collect::<Vec<_>>()
+                .join("");
+            format!("~~{}~~", inner)
+        }
+        // Container nodes
+        Node::Root(root) => root
+            .children
+            .iter()
+            .map(extract_text)
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+/// Set a bit in the null bitmap
+fn set_null_bit(bitmap: &mut [u8], index: usize) {
+    let byte_idx = index / 8;
+    let bit_idx = index % 8;
+    bitmap[byte_idx] |= 1 << bit_idx;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_headings() {
+        let input = "# Title\n## Subtitle\n### Section";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 3);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("h1".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(0, 1),
+            Some(&SchemaValue::String("Title".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(1, 0),
+            Some(&SchemaValue::String("h2".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(1, 1),
+            Some(&SchemaValue::String("Subtitle".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(2, 0),
+            Some(&SchemaValue::String("h3".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_paragraph() {
+        let input = "This is a paragraph with **bold** and *italic* text.";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("p".to_string()))
+        );
+        let content = if let Some(SchemaValue::String(s)) = ir.get_value(0, 1) {
+            s
+        } else {
+            panic!("Expected string content");
+        };
+        assert!(content.contains("**bold**"));
+        assert!(content.contains("*italic*"));
+    }
+
+    #[test]
+    fn test_unordered_list() {
+        let input = "- Item 1\n- Item 2\n- Item 3";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("ul".to_string()))
+        );
+        let content = if let Some(SchemaValue::String(s)) = ir.get_value(0, 1) {
+            s
+        } else {
+            panic!("Expected string content");
+        };
+        assert!(content.contains("Item 1"));
+        assert!(content.contains("Item 2"));
+        assert!(content.contains("Item 3"));
+    }
+
+    #[test]
+    fn test_ordered_list() {
+        let input = "1. First\n2. Second\n3. Third";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("ol".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_code_block_with_language() {
+        let input = "```rust\nfn main() {}\n```";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("code".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(0, 1),
+            Some(&SchemaValue::String("fn main() {}".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(0, 2),
+            Some(&SchemaValue::String("rust".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_code_block_no_language() {
+        let input = "```\ncode here\n```";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("code".to_string()))
+        );
+        assert_eq!(ir.get_value(0, 2), Some(&SchemaValue::Null));
+        assert!(ir.is_null(0, 2));
+    }
+
+    #[test]
+    fn test_blockquote() {
+        let input = "> This is a quote\n> with multiple lines";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("quote".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_horizontal_rule() {
+        let input = "---";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("hr".to_string()))
+        );
+        assert_eq!(
+            ir.get_value(0, 1),
+            Some(&SchemaValue::String("".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_table() {
+        let input = "| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("table".to_string()))
+        );
+        let meta = if let Some(SchemaValue::String(s)) = ir.get_value(0, 2) {
+            s
+        } else {
+            panic!("Expected string meta");
+        };
+        assert!(meta.contains("x2")); // 2 columns
+    }
+
+    #[test]
+    fn test_link_as_block() {
+        let input = "[Link Text](https://example.com)";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        // Links in paragraphs are treated as paragraph content with inline markdown
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("p".to_string()))
+        );
+        let content = if let Some(SchemaValue::String(s)) = ir.get_value(0, 1) {
+            s
+        } else {
+            panic!("Expected string content");
+        };
+        assert!(content.contains("[Link Text](https://example.com)"));
+    }
+
+    #[test]
+    fn test_image_as_block() {
+        let input = "![Alt Text](image.jpg)";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("p".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_mixed_document() {
+        let input = "# Header\n\nSome text.\n\n- Item 1\n- Item 2\n\n```\ncode\n```";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert!(ir.header.row_count >= 3);
+        // Should have: h1, p, ul, code
+    }
+
+    #[test]
+    fn test_inline_code_preserved() {
+        let input = "This has `inline code` in it.";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        let content = if let Some(SchemaValue::String(s)) = ir.get_value(0, 1) {
+            s
+        } else {
+            panic!("Expected string content");
+        };
+        assert!(content.contains("`inline code`"));
+    }
+
+    #[test]
+    fn test_nested_list() {
+        let input = "- Level 1\n  - Level 2\n    - Level 3";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert_eq!(ir.header.row_count, 1);
+        assert_eq!(
+            ir.get_value(0, 0),
+            Some(&SchemaValue::String("ul".to_string()))
+        );
+        let content = if let Some(SchemaValue::String(s)) = ir.get_value(0, 1) {
+            s
+        } else {
+            panic!("Expected string content");
+        };
+        // Should preserve indentation
+        assert!(content.contains("Level 1"));
+        assert!(content.contains("Level 2"));
+    }
+
+    #[test]
+    fn test_empty_document() {
+        let input = "";
+        let result = MarkdownDocParser::parse(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_null_bitmap_for_code_without_lang() {
+        let input = "```\ntest\n```\n\n```python\nprint()\n```";
+        let ir = MarkdownDocParser::parse(input).unwrap();
+
+        assert!(ir.header.has_flag(FLAG_HAS_NULLS));
+        assert!(ir.is_null(0, 2)); // First code block has no language
+        assert!(!ir.is_null(1, 2)); // Second has language
+    }
+}

--- a/src/encoders/algorithms/schema/parsers/mod.rs
+++ b/src/encoders/algorithms/schema/parsers/mod.rs
@@ -1,4 +1,7 @@
 pub mod json;
+#[allow(dead_code)]
+pub mod markdown;
+pub mod markdown_doc;
 
 use crate::encoders::algorithms::schema::types::IntermediateRepresentation;
 
@@ -11,3 +14,4 @@ pub trait InputParser {
 }
 
 pub use json::JsonParser;
+pub use markdown_doc::MarkdownDocParser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,9 @@ pub use encoders::streaming::{StreamingDecoder, StreamingEncoder};
 // Expose schema encoding functions for CLI
 pub use encoders::algorithms::schema::{
     SchemaCompressionAlgo, decode_fiche, decode_fiche_path, decode_schema, encode_fiche,
-    encode_fiche_light, encode_fiche_minified, encode_fiche_path, encode_fiche_readable,
+    encode_fiche_ascii, encode_fiche_light, encode_fiche_minified, encode_fiche_path,
+    encode_fiche_readable, encode_markdown_fiche, encode_markdown_fiche_ascii,
+    encode_markdown_fiche_light, encode_markdown_fiche_markdown, encode_markdown_fiche_readable,
     encode_schema,
 };
 


### PR DESCRIPTION
## Summary
- Add `FicheMode` enum (renamed from `FicheLevel`) with `markdown` mode
- Implement `serialize_markdown()` for inline markdown-like fiche output
- Add `MarkdownDocParser` for parsing markdown documents to IR
- Wire `--mode markdown` flag in CLI (replaces `--level`)

## Token Efficiency Results (Gruber 27KB syntax doc)
| Format | Bytes | Tokens | Time |
|--------|-------|--------|------|
| Raw Markdown | 27,431 | 29.4k | 6s |
| ASCII fiche | 25,408 | 26.3k | 5s |
| **Markdown fiche** | 25,822 | **25.9k** | 6s |

Markdown mode achieves **12% fewer tokens** than raw markdown by using inline format with familiar syntax patterns (`#1`, `p`, `-1`, etc.) that tokenizers handle efficiently.

## Test Plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] Manual testing with Gruber markdown syntax doc
- [x] Cold parsing verified - Haiku understands format without explanation

Closes #138