### PR TITLE
pin nebuchadnezzar workflows to @v1

### DIFF
--- a/.github/workflows/follow-the-white-rabbit.yml
+++ b/.github/workflows/follow-the-white-rabbit.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   release:
-    uses: coryzibell/nebuchadnezzar/.github/workflows/follow-the-white-rabbit.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/follow-the-white-rabbit.yml@v1
     secrets:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/knock-knock.yml
+++ b/.github/workflows/knock-knock.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   publish:
-    uses: coryzibell/nebuchadnezzar/.github/workflows/knock-knock.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/knock-knock.yml@v1
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/wake-up.yml
+++ b/.github/workflows/wake-up.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   ci:
-    uses: coryzibell/nebuchadnezzar/.github/workflows/wake-up.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/wake-up.yml@v1
     secrets:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   wasm:
     name: Build WASM
-    uses: coryzibell/nebuchadnezzar/.github/workflows/there-is-no-spoon.yml@main
+    uses: coryzibell/nebuchadnezzar/.github/workflows/there-is-no-spoon.yml@v1
     with:
       features: wasm
       no-default-features: true

--- a/src/encoders/algorithms/errors.rs
+++ b/src/encoders/algorithms/errors.rs
@@ -63,7 +63,7 @@ pub enum DecodeError {
 
 /// Truncate a string to at most `max_chars` characters, appending "..." if truncated.
 /// Uses char-count instead of byte-index to avoid panics on multi-byte UTF-8 input.
-fn safe_truncate(s: &str, max_chars: usize) -> String {
+pub(crate) fn safe_truncate(s: &str, max_chars: usize) -> String {
     if s.chars().count() > max_chars {
         let truncated: String = s.chars().take(max_chars).collect();
         format!("{}...", truncated)
@@ -477,5 +477,30 @@ mod tests {
         unsafe {
             std::env::remove_var("NO_COLOR");
         }
+    }
+
+    #[test]
+    fn test_safe_truncate_multibyte() {
+        let input = "\u{1F3AD}".repeat(20); // 20 chars, 80 bytes
+        let result = safe_truncate(&input, 10);
+        assert_eq!(result, format!("{}...", "\u{1F3AD}".repeat(10)));
+    }
+
+    #[test]
+    fn test_safe_truncate_no_truncation() {
+        assert_eq!(safe_truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_safe_truncate_exact_boundary() {
+        assert_eq!(safe_truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_invalid_character_multibyte_no_panic() {
+        let input = "\u{1F711}".repeat(30); // 30 alchemical symbols, 120 bytes
+        // This must not panic -- the old &input[..60] would have
+        let err = DecodeError::invalid_character('x', 0, &input, "abc");
+        let _ = format!("{}", err);
     }
 }

--- a/src/encoders/algorithms/errors.rs
+++ b/src/encoders/algorithms/errors.rs
@@ -61,20 +61,24 @@ pub enum DecodeError {
     },
 }
 
+/// Truncate a string to at most `max_chars` characters, appending "..." if truncated.
+/// Uses char-count instead of byte-index to avoid panics on multi-byte UTF-8 input.
+fn safe_truncate(s: &str, max_chars: usize) -> String {
+    if s.chars().count() > max_chars {
+        let truncated: String = s.chars().take(max_chars).collect();
+        format!("{}...", truncated)
+    } else {
+        s.to_string()
+    }
+}
+
 impl DecodeError {
     /// Create an InvalidCharacter error with context
     pub fn invalid_character(c: char, position: usize, input: &str, valid_chars: &str) -> Self {
-        // Truncate long inputs
-        let display_input = if input.len() > 60 {
-            format!("{}...", &input[..60])
-        } else {
-            input.to_string()
-        };
-
         DecodeError::InvalidCharacter {
             char: c,
             position,
-            input: display_input,
+            input: safe_truncate(input, 60),
             valid_chars: valid_chars.to_string(),
         }
     }
@@ -94,17 +98,10 @@ impl DecodeError {
 
     /// Create an InvalidWord error for word-based decoding
     pub fn invalid_word(word: &str, position: usize, input: &str) -> Self {
-        // Truncate long inputs
-        let display_input = if input.len() > 80 {
-            format!("{}...", &input[..80])
-        } else {
-            input.to_string()
-        };
-
         DecodeError::InvalidWord {
             word: word.to_string(),
             position,
-            input: display_input,
+            input: safe_truncate(input, 80),
         }
     }
 }
@@ -149,11 +146,7 @@ impl fmt::Display for DecodeError {
                 writeln!(f)?;
 
                 // Hint with valid characters (truncate if too long)
-                let hint_chars = if valid_chars.len() > 80 {
-                    format!("{}...", &valid_chars[..80])
-                } else {
-                    valid_chars.clone()
-                };
+                let hint_chars = safe_truncate(valid_chars, 80);
 
                 if use_color {
                     write!(f, "\x1b[1;36mhint:\x1b[0m valid characters: {}", hint_chars)?;

--- a/src/encoders/algorithms/schema/frame.rs
+++ b/src/encoders/algorithms/schema/frame.rs
@@ -1,3 +1,4 @@
+use super::super::errors::safe_truncate;
 use super::display96;
 use super::types::SchemaError;
 use num_bigint::BigUint;
@@ -42,12 +43,8 @@ pub fn encode_framed(binary: &[u8]) -> String {
 /// let binary = decode_framed(framed)?;
 /// ```
 pub fn decode_framed(encoded: &str) -> Result<Vec<u8>, SchemaError> {
-    // Show preview of what was received
-    let preview = if encoded.len() > 40 {
-        format!("{}...", &encoded.chars().take(40).collect::<String>())
-    } else {
-        encoded.to_string()
-    };
+    // Show preview of what was received (char-safe truncation)
+    let preview = safe_truncate(encoded, 40);
 
     // Validate frame delimiters
     if !encoded.starts_with(FRAME_START) {

--- a/src/encoders/algorithms/schema/serializers/json.rs
+++ b/src/encoders/algorithms/schema/serializers/json.rs
@@ -215,7 +215,7 @@ fn unflatten_object(flat: HashMap<String, Value>) -> Value {
     #[allow(clippy::type_complexity)]
     let mut array_entries: Vec<(String, Vec<(usize, String, Value)>)> =
         array_elements.into_iter().collect();
-    array_entries.sort_by(|(a, _), (b, _)| b.len().cmp(&a.len()));
+    array_entries.sort_by_key(|(b, _)| std::cmp::Reverse(b.len()));
 
     for (array_path, mut elements) in array_entries {
         // Sort by index


### PR DESCRIPTION
## Summary
- Pin all reusable workflow references from `coryzibell/nebuchadnezzar/...@main` to `@v1`
- Fix pre-existing clippy `unnecessary_sort_by` lint in json serializer
- Follows the v1.0.0 release and floating `v1` tag creation in nebuchadnezzar

Refs: coryzibell/nebuchadnezzar#8, coryzibell/nebuchadnezzar#6